### PR TITLE
fix: don't add EncryptionKey for Sops if target is SecretsManager

### DIFF
--- a/.tool-versions
+++ b/.tool-versions
@@ -1,1 +1,3 @@
 golang 1.22.3
+yarn 1.22.19
+nodejs 20.12.2

--- a/src/SopsSync.ts
+++ b/src/SopsSync.ts
@@ -365,7 +365,8 @@ export class SopsSync extends Construct {
         Format: sopsFileFormat,
         StringifiedValues: this.stringifiedValues,
         ParameterName: props.parameterName,
-        EncryptionKey: props.encryptionKey?.keyId,
+        EncryptionKey:
+          props.secret !== undefined ? undefined : props.encryptionKey?.keyId,
       },
     });
     this.versionId = cr.getAttString('VersionId');

--- a/test/secret-asset.integ.snapshot/SecretIntegrationAsset.assets.json
+++ b/test/secret-asset.integ.snapshot/SecretIntegrationAsset.assets.json
@@ -1,15 +1,15 @@
 {
   "version": "36.0.0",
   "files": {
-    "bb69ba524a08169cedf946b0484af5701b17fa90f4a9654856a42dbd394a2bc8": {
+    "5c8456d08eda68f6317c8cf525f4836c7081ae3e4a6b9c6b4035e1a969be1653": {
       "source": {
-        "path": "asset.bb69ba524a08169cedf946b0484af5701b17fa90f4a9654856a42dbd394a2bc8.zip",
+        "path": "asset.5c8456d08eda68f6317c8cf525f4836c7081ae3e4a6b9c6b4035e1a969be1653.zip",
         "packaging": "file"
       },
       "destinations": {
         "current_account-current_region": {
           "bucketName": "cdk-hnb659fds-assets-${AWS::AccountId}-${AWS::Region}",
-          "objectKey": "bb69ba524a08169cedf946b0484af5701b17fa90f4a9654856a42dbd394a2bc8.zip",
+          "objectKey": "5c8456d08eda68f6317c8cf525f4836c7081ae3e4a6b9c6b4035e1a969be1653.zip",
           "assumeRoleArn": "arn:${AWS::Partition}:iam::${AWS::AccountId}:role/cdk-hnb659fds-file-publishing-role-${AWS::AccountId}-${AWS::Region}"
         }
       }
@@ -79,7 +79,7 @@
         }
       }
     },
-    "f7fbc998771a7e463d058dab6195dd6de18ce041a05e3f961382fedfb441a9cb": {
+    "4ba8a0e4a61819b03d21ec2f1f871610931d585ce2721290af06b44affc654e9": {
       "source": {
         "path": "SecretIntegrationAsset.template.json",
         "packaging": "file"
@@ -87,7 +87,7 @@
       "destinations": {
         "current_account-current_region": {
           "bucketName": "cdk-hnb659fds-assets-${AWS::AccountId}-${AWS::Region}",
-          "objectKey": "f7fbc998771a7e463d058dab6195dd6de18ce041a05e3f961382fedfb441a9cb.json",
+          "objectKey": "4ba8a0e4a61819b03d21ec2f1f871610931d585ce2721290af06b44affc654e9.json",
           "assumeRoleArn": "arn:${AWS::Partition}:iam::${AWS::AccountId}:role/cdk-hnb659fds-file-publishing-role-${AWS::AccountId}-${AWS::Region}"
         }
       }

--- a/test/secret-asset.integ.snapshot/SecretIntegrationAsset.template.json
+++ b/test/secret-asset.integ.snapshot/SecretIntegrationAsset.template.json
@@ -3,7 +3,8 @@
   "SopsSecretJSON72040543": {
    "Type": "AWS::SecretsManager::Secret",
    "Properties": {
-    "GenerateSecretString": {}
+    "GenerateSecretString": {},
+    "KmsKeyId": "arn:aws:kms:us-west-2:111122223333:key/1234abcd-12ab-34cd-56ef-1234567890ab"
    },
    "UpdateReplacePolicy": "Delete",
    "DeletionPolicy": "Delete"
@@ -123,6 +124,16 @@
       },
       {
        "Action": [
+        "kms:Decrypt",
+        "kms:Encrypt",
+        "kms:ReEncrypt*",
+        "kms:GenerateDataKey*"
+       ],
+       "Effect": "Allow",
+       "Resource": "arn:aws:kms:us-west-2:111122223333:key/1234abcd-12ab-34cd-56ef-1234567890ab"
+      },
+      {
+       "Action": [
         "secretsmanager:PutSecretValue",
         "secretsmanager:UpdateSecret"
        ],
@@ -229,7 +240,7 @@
      "S3Bucket": {
       "Fn::Sub": "cdk-hnb659fds-assets-${AWS::AccountId}-${AWS::Region}"
      },
-     "S3Key": "bb69ba524a08169cedf946b0484af5701b17fa90f4a9654856a42dbd394a2bc8.zip"
+     "S3Key": "5c8456d08eda68f6317c8cf525f4836c7081ae3e4a6b9c6b4035e1a969be1653.zip"
     },
     "Environment": {
      "Variables": {

--- a/test/secret-inline.integ.snapshot/SecretIntegrationInline.assets.json
+++ b/test/secret-inline.integ.snapshot/SecretIntegrationInline.assets.json
@@ -1,20 +1,20 @@
 {
   "version": "36.0.0",
   "files": {
-    "bb69ba524a08169cedf946b0484af5701b17fa90f4a9654856a42dbd394a2bc8": {
+    "5c8456d08eda68f6317c8cf525f4836c7081ae3e4a6b9c6b4035e1a969be1653": {
       "source": {
-        "path": "asset.bb69ba524a08169cedf946b0484af5701b17fa90f4a9654856a42dbd394a2bc8.zip",
+        "path": "asset.5c8456d08eda68f6317c8cf525f4836c7081ae3e4a6b9c6b4035e1a969be1653.zip",
         "packaging": "file"
       },
       "destinations": {
         "current_account-current_region": {
           "bucketName": "cdk-hnb659fds-assets-${AWS::AccountId}-${AWS::Region}",
-          "objectKey": "bb69ba524a08169cedf946b0484af5701b17fa90f4a9654856a42dbd394a2bc8.zip",
+          "objectKey": "5c8456d08eda68f6317c8cf525f4836c7081ae3e4a6b9c6b4035e1a969be1653.zip",
           "assumeRoleArn": "arn:${AWS::Partition}:iam::${AWS::AccountId}:role/cdk-hnb659fds-file-publishing-role-${AWS::AccountId}-${AWS::Region}"
         }
       }
     },
-    "73629fb8e02143b715cd337c35f7f983845f89768b5261eccdd19c8dc9e5542e": {
+    "663edd5aebed0913cd8277585eecce64ea586ae0adcaabe91e6d26efa9c09bba": {
       "source": {
         "path": "SecretIntegrationInline.template.json",
         "packaging": "file"
@@ -22,7 +22,7 @@
       "destinations": {
         "current_account-current_region": {
           "bucketName": "cdk-hnb659fds-assets-${AWS::AccountId}-${AWS::Region}",
-          "objectKey": "73629fb8e02143b715cd337c35f7f983845f89768b5261eccdd19c8dc9e5542e.json",
+          "objectKey": "663edd5aebed0913cd8277585eecce64ea586ae0adcaabe91e6d26efa9c09bba.json",
           "assumeRoleArn": "arn:${AWS::Partition}:iam::${AWS::AccountId}:role/cdk-hnb659fds-file-publishing-role-${AWS::AccountId}-${AWS::Region}"
         }
       }

--- a/test/secret-inline.integ.snapshot/SecretIntegrationInline.template.json
+++ b/test/secret-inline.integ.snapshot/SecretIntegrationInline.template.json
@@ -196,7 +196,7 @@
      "S3Bucket": {
       "Fn::Sub": "cdk-hnb659fds-assets-${AWS::AccountId}-${AWS::Region}"
      },
-     "S3Key": "bb69ba524a08169cedf946b0484af5701b17fa90f4a9654856a42dbd394a2bc8.zip"
+     "S3Key": "5c8456d08eda68f6317c8cf525f4836c7081ae3e4a6b9c6b4035e1a969be1653.zip"
     },
     "Environment": {
      "Variables": {

--- a/test/secret-manual.integ.snapshot/SecretIntegrationAsset.assets.json
+++ b/test/secret-manual.integ.snapshot/SecretIntegrationAsset.assets.json
@@ -1,20 +1,20 @@
 {
   "version": "36.0.0",
   "files": {
-    "bb69ba524a08169cedf946b0484af5701b17fa90f4a9654856a42dbd394a2bc8": {
+    "5c8456d08eda68f6317c8cf525f4836c7081ae3e4a6b9c6b4035e1a969be1653": {
       "source": {
-        "path": "asset.bb69ba524a08169cedf946b0484af5701b17fa90f4a9654856a42dbd394a2bc8.zip",
+        "path": "asset.5c8456d08eda68f6317c8cf525f4836c7081ae3e4a6b9c6b4035e1a969be1653.zip",
         "packaging": "file"
       },
       "destinations": {
         "current_account-current_region": {
           "bucketName": "cdk-hnb659fds-assets-${AWS::AccountId}-${AWS::Region}",
-          "objectKey": "bb69ba524a08169cedf946b0484af5701b17fa90f4a9654856a42dbd394a2bc8.zip",
+          "objectKey": "5c8456d08eda68f6317c8cf525f4836c7081ae3e4a6b9c6b4035e1a969be1653.zip",
           "assumeRoleArn": "arn:${AWS::Partition}:iam::${AWS::AccountId}:role/cdk-hnb659fds-file-publishing-role-${AWS::AccountId}-${AWS::Region}"
         }
       }
     },
-    "4d6dc6e1bf26943542af9150df1a3ba98d8302b1332e4f65bacdbb1dd60396c3": {
+    "b20d572128cbc49c34e0fd57338f629aa2b41be78a2a06a5d6dc16c578c03986": {
       "source": {
         "path": "SecretIntegrationAsset.template.json",
         "packaging": "file"
@@ -22,7 +22,7 @@
       "destinations": {
         "current_account-current_region": {
           "bucketName": "cdk-hnb659fds-assets-${AWS::AccountId}-${AWS::Region}",
-          "objectKey": "4d6dc6e1bf26943542af9150df1a3ba98d8302b1332e4f65bacdbb1dd60396c3.json",
+          "objectKey": "b20d572128cbc49c34e0fd57338f629aa2b41be78a2a06a5d6dc16c578c03986.json",
           "assumeRoleArn": "arn:${AWS::Partition}:iam::${AWS::AccountId}:role/cdk-hnb659fds-file-publishing-role-${AWS::AccountId}-${AWS::Region}"
         }
       }

--- a/test/secret-manual.integ.snapshot/SecretIntegrationAsset.template.json
+++ b/test/secret-manual.integ.snapshot/SecretIntegrationAsset.template.json
@@ -70,7 +70,7 @@
      "S3Bucket": {
       "Fn::Sub": "cdk-hnb659fds-assets-${AWS::AccountId}-${AWS::Region}"
      },
-     "S3Key": "bb69ba524a08169cedf946b0484af5701b17fa90f4a9654856a42dbd394a2bc8.zip"
+     "S3Key": "5c8456d08eda68f6317c8cf525f4836c7081ae3e4a6b9c6b4035e1a969be1653.zip"
     },
     "Environment": {
      "Variables": {

--- a/test/secret-multikms.integ.snapshot/SecretMultiKms.assets.json
+++ b/test/secret-multikms.integ.snapshot/SecretMultiKms.assets.json
@@ -1,20 +1,20 @@
 {
   "version": "36.0.0",
   "files": {
-    "bb69ba524a08169cedf946b0484af5701b17fa90f4a9654856a42dbd394a2bc8": {
+    "5c8456d08eda68f6317c8cf525f4836c7081ae3e4a6b9c6b4035e1a969be1653": {
       "source": {
-        "path": "asset.bb69ba524a08169cedf946b0484af5701b17fa90f4a9654856a42dbd394a2bc8.zip",
+        "path": "asset.5c8456d08eda68f6317c8cf525f4836c7081ae3e4a6b9c6b4035e1a969be1653.zip",
         "packaging": "file"
       },
       "destinations": {
         "current_account-current_region": {
           "bucketName": "cdk-hnb659fds-assets-${AWS::AccountId}-${AWS::Region}",
-          "objectKey": "bb69ba524a08169cedf946b0484af5701b17fa90f4a9654856a42dbd394a2bc8.zip",
+          "objectKey": "5c8456d08eda68f6317c8cf525f4836c7081ae3e4a6b9c6b4035e1a969be1653.zip",
           "assumeRoleArn": "arn:${AWS::Partition}:iam::${AWS::AccountId}:role/cdk-hnb659fds-file-publishing-role-${AWS::AccountId}-${AWS::Region}"
         }
       }
     },
-    "71fef4c17cc89ee4f084f68262ca5d0906a0f3339374be125a2457c37c2aacd3": {
+    "a43de51d10514296151ba5d5ef8fe8684a0bac362a49d724faf6b32b2c8d4d74": {
       "source": {
         "path": "SecretMultiKms.template.json",
         "packaging": "file"
@@ -22,7 +22,7 @@
       "destinations": {
         "current_account-current_region": {
           "bucketName": "cdk-hnb659fds-assets-${AWS::AccountId}-${AWS::Region}",
-          "objectKey": "71fef4c17cc89ee4f084f68262ca5d0906a0f3339374be125a2457c37c2aacd3.json",
+          "objectKey": "a43de51d10514296151ba5d5ef8fe8684a0bac362a49d724faf6b32b2c8d4d74.json",
           "assumeRoleArn": "arn:${AWS::Partition}:iam::${AWS::AccountId}:role/cdk-hnb659fds-file-publishing-role-${AWS::AccountId}-${AWS::Region}"
         }
       }

--- a/test/secret-multikms.integ.snapshot/SecretMultiKms.template.json
+++ b/test/secret-multikms.integ.snapshot/SecretMultiKms.template.json
@@ -116,7 +116,7 @@
      "S3Bucket": {
       "Fn::Sub": "cdk-hnb659fds-assets-${AWS::AccountId}-${AWS::Region}"
      },
-     "S3Key": "bb69ba524a08169cedf946b0484af5701b17fa90f4a9654856a42dbd394a2bc8.zip"
+     "S3Key": "5c8456d08eda68f6317c8cf525f4836c7081ae3e4a6b9c6b4035e1a969be1653.zip"
     },
     "Environment": {
      "Variables": {


### PR DESCRIPTION
One Team had problems with the latest version. Even if this option should not break things (famous last words), we remove it to hopefully not cause problems for other users