### PR TITLE
feat: Support placing the lambda into a VPC

### DIFF
--- a/API.md
+++ b/API.md
@@ -962,13 +962,14 @@ The current versionId of the secret populated via this resource.
 ```typescript
 import { SopsSyncProvider } from 'cdk-sops-secrets'
 
-new SopsSyncProvider(scope: Construct, id?: string)
+new SopsSyncProvider(scope: Construct, id?: string, props?: SopsSyncProviderProps)
 ```
 
 | **Name** | **Type** | **Description** |
 | --- | --- | --- |
 | <code><a href="#cdk-sops-secrets.SopsSyncProvider.Initializer.parameter.scope">scope</a></code> | <code>constructs.Construct</code> | *No description.* |
 | <code><a href="#cdk-sops-secrets.SopsSyncProvider.Initializer.parameter.id">id</a></code> | <code>string</code> | *No description.* |
+| <code><a href="#cdk-sops-secrets.SopsSyncProvider.Initializer.parameter.props">props</a></code> | <code><a href="#cdk-sops-secrets.SopsSyncProviderProps">SopsSyncProviderProps</a></code> | *No description.* |
 
 ---
 
@@ -981,6 +982,12 @@ new SopsSyncProvider(scope: Construct, id?: string)
 ##### `id`<sup>Optional</sup> <a name="id" id="cdk-sops-secrets.SopsSyncProvider.Initializer.parameter.id"></a>
 
 - *Type:* string
+
+---
+
+##### `props`<sup>Optional</sup> <a name="props" id="cdk-sops-secrets.SopsSyncProvider.Initializer.parameter.props"></a>
+
+- *Type:* <a href="#cdk-sops-secrets.SopsSyncProviderProps">SopsSyncProviderProps</a>
 
 ---
 
@@ -3385,6 +3392,67 @@ public readonly secret: ISecret;
 - *Type:* aws-cdk-lib.aws_secretsmanager.ISecret
 
 The secret that will be populated with the encrypted sops file content.
+
+---
+
+### SopsSyncProviderProps <a name="SopsSyncProviderProps" id="cdk-sops-secrets.SopsSyncProviderProps"></a>
+
+Configuration options for a custom SopsSyncProvider.
+
+#### Initializer <a name="Initializer" id="cdk-sops-secrets.SopsSyncProviderProps.Initializer"></a>
+
+```typescript
+import { SopsSyncProviderProps } from 'cdk-sops-secrets'
+
+const sopsSyncProviderProps: SopsSyncProviderProps = { ... }
+```
+
+#### Properties <a name="Properties" id="Properties"></a>
+
+| **Name** | **Type** | **Description** |
+| --- | --- | --- |
+| <code><a href="#cdk-sops-secrets.SopsSyncProviderProps.property.securityGroups">securityGroups</a></code> | <code>aws-cdk-lib.aws_ec2.ISecurityGroup[]</code> | Only if `vpc` is supplied: The list of security groups to associate with the Lambda's network interfaces. |
+| <code><a href="#cdk-sops-secrets.SopsSyncProviderProps.property.vpc">vpc</a></code> | <code>aws-cdk-lib.aws_ec2.IVpc</code> | VPC network to place Lambda network interfaces. |
+| <code><a href="#cdk-sops-secrets.SopsSyncProviderProps.property.vpcSubnets">vpcSubnets</a></code> | <code>aws-cdk-lib.aws_ec2.SubnetSelection</code> | Where to place the network interfaces within the VPC. |
+
+---
+
+##### `securityGroups`<sup>Optional</sup> <a name="securityGroups" id="cdk-sops-secrets.SopsSyncProviderProps.property.securityGroups"></a>
+
+```typescript
+public readonly securityGroups: ISecurityGroup[];
+```
+
+- *Type:* aws-cdk-lib.aws_ec2.ISecurityGroup[]
+- *Default:* A dedicated security group will be created for the lambda function.
+
+Only if `vpc` is supplied: The list of security groups to associate with the Lambda's network interfaces.
+
+---
+
+##### `vpc`<sup>Optional</sup> <a name="vpc" id="cdk-sops-secrets.SopsSyncProviderProps.property.vpc"></a>
+
+```typescript
+public readonly vpc: IVpc;
+```
+
+- *Type:* aws-cdk-lib.aws_ec2.IVpc
+- *Default:* Lambda function is not placed within a VPC.
+
+VPC network to place Lambda network interfaces.
+
+---
+
+##### `vpcSubnets`<sup>Optional</sup> <a name="vpcSubnets" id="cdk-sops-secrets.SopsSyncProviderProps.property.vpcSubnets"></a>
+
+```typescript
+public readonly vpcSubnets: SubnetSelection;
+```
+
+- *Type:* aws-cdk-lib.aws_ec2.SubnetSelection
+- *Default:* Subnets will be chosen automatically.
+
+Where to place the network interfaces within the VPC.
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -127,6 +127,28 @@ const secret = new SopsSecret(this, 'SopsComplexSecretJSON', {
 });
 ```
 
+
+### Use a VPC for the Lambda Function
+
+Internally, SopsSync uses a lambda function. In some environments it may be necessary to place this lambda function into a VPC and configure subnets and/or security groups for it.
+This can be done by creating a custom `SopsSyncProvider`, setting the required networking configuration and passing it to the secret like this:
+
+```typescript
+// Create the provider
+const provider = new SopsSyncProvider(this, 'CustomSopsSyncProvider', {
+  vpc: myVpc,
+  vpcSubnets: subnetSelection,
+  securityGroups: [mySecurityGroup],
+});
+// create the secret and pass the the provider to it
+const secret = new SopsSecret(this, 'SopsSecret', {
+  sopsProvider: provider,
+  secretName: 'myCoolSecret',
+  sopsFilePath: 'secrets/sopsfile-encrypted.json',
+});
+```
+
+
 ### UploadType: INLINE / ASSET
 
 I decided, that the default behavior should be "INLINE" because of the following consideration:

--- a/src/SopsSync.ts
+++ b/src/SopsSync.ts
@@ -9,6 +9,7 @@ import {
   CustomResource,
   FileSystem,
 } from 'aws-cdk-lib';
+import { ISecurityGroup, IVpc, SubnetSelection } from 'aws-cdk-lib/aws-ec2';
 import {
   IGrantable,
   IRole,
@@ -169,10 +170,16 @@ export interface SopsSyncProps extends SopsSyncOptions {
   readonly encryptionKey?: IKey;
 }
 
+export interface SopsSyncProviderProps {
+  readonly vpc?: IVpc;
+  readonly vpcSubnets?: SubnetSelection;
+  readonly securityGroups?: ISecurityGroup[];
+}
+
 export class SopsSyncProvider extends SingletonFunction implements IGrantable {
   private sopsAgeKeys: SecretValue[];
 
-  constructor(scope: Construct, id?: string) {
+  constructor(scope: Construct, id?: string, props?: SopsSyncProviderProps) {
     super(scope, id ?? 'SopsSyncProvider', {
       code: Code.fromAsset(
         scope.node.tryGetContext('sops_sync_provider_asset_path') ||
@@ -190,6 +197,9 @@ export class SopsSyncProvider extends SingletonFunction implements IGrantable {
             ),
         }),
       },
+      vpc: props?.vpc,
+      vpcSubnets: props?.vpcSubnets,
+      securityGroups: props?.securityGroups,
     });
     this.sopsAgeKeys = [];
   }

--- a/src/SopsSync.ts
+++ b/src/SopsSync.ts
@@ -170,9 +170,27 @@ export interface SopsSyncProps extends SopsSyncOptions {
   readonly encryptionKey?: IKey;
 }
 
+/**
+ * Configuration options for a custom SopsSyncProvider.
+ */
 export interface SopsSyncProviderProps {
+  /**
+   * VPC network to place Lambda network interfaces.
+   *
+   * @default - Lambda function is not placed within a VPC.
+   */
   readonly vpc?: IVpc;
+  /**
+   * Where to place the network interfaces within the VPC.
+   *
+   * @default - Subnets will be chosen automatically.
+   */
   readonly vpcSubnets?: SubnetSelection;
+  /**
+   * Only if `vpc` is supplied: The list of security groups to associate with the Lambda's network interfaces.
+   *
+   * @default - A dedicated security group will be created for the lambda function.
+   */
   readonly securityGroups?: ISecurityGroup[];
 }
 


### PR DESCRIPTION
In our organization, all lambdas must be placed into a VPC, or deployment will fail. We also must set the correct subnets and security group. 

This small PR adds the necessary parameters to configure the lambda function accordingly.

Example Usage:
```typescript
const sopsProvider = new SopsSyncProvider(this, "SopsSyncProvider", {
  vpc: vpc,
  vpcSubnets: subnetSelection,
  securityGroups: [securityGroup],
});
const secret = new SopsSecret(this, "SopsMySecret", {
  sopsFilePath: "sopsfile.yaml",
  sopsProvider,
});
```

Should I add this example to the "Advanced Configuration Examples"? Please let me know if anything else is missing.