### PR TITLE
feat: refactor / additional flag autoGenerateIamPermissions

### DIFF
--- a/.gitleaks.toml
+++ b/.gitleaks.toml
@@ -1,0 +1,40 @@
+[extend]
+useDefault = true
+
+[[rules]]
+id = "generic-api-key"
+# all the other attributes from the default rule are inherited
+
+    [[rules.allowlists]]
+    regexTarget = "line"
+    regexes = [ 
+      '''objectKey''',
+      '''S3Key''',
+      '''SopsAgeKey''',
+      '''s3Key''',
+    ]
+
+[[rules]]
+id = "private-key"
+
+    [[rules.allowlists]]
+    regexTarget = "line"
+    regexes = [
+      '''(.*)OAdqlMznWINBDoyR\+PESgQJlUptwnh(.*)''',
+    ]
+
+[allowlist]
+description = "global allow list"
+paths = [
+  '''\.gitleaks\.toml''',
+  '''lambda/events/(.*?)json''',
+  '''lambda/__snapshots__/(.*?)snap''',
+  '''test-secrets/(.*?)(json|yaml|yml|env|binary)''',
+  '''test/(.*)\.integ\.snapshot/(.*?)json'''
+]
+
+regexTarget = "match"
+regexes = [
+  '''AGE-SECRET-KEY-1EFUWJ0G2XJTJFWTAM2DGMA4VCK3R05W58FSMHZP3MZQ0ZTAQEAFQC6T7T3''',
+]
+

--- a/API.md
+++ b/API.md
@@ -1717,12 +1717,11 @@ const multiStringParameterProps: MultiStringParameterProps = { ... }
 
 | **Name** | **Type** | **Description** |
 | --- | --- | --- |
+| <code><a href="#cdk-sops-secrets.MultiStringParameterProps.property.autoGenerateIamPermissions">autoGenerateIamPermissions</a></code> | <code>boolean</code> | Should this construct automatically create IAM permissions? |
 | <code><a href="#cdk-sops-secrets.MultiStringParameterProps.property.convertToJSON">convertToJSON</a></code> | <code>boolean</code> | Should the encrypted sops value should be converted to JSON? |
-| <code><a href="#cdk-sops-secrets.MultiStringParameterProps.property.creationType">creationType</a></code> | <code><a href="#cdk-sops-secrets.CreationType">CreationType</a></code> | *No description.* |
 | <code><a href="#cdk-sops-secrets.MultiStringParameterProps.property.flatten">flatten</a></code> | <code>boolean</code> | Should the structure be flattened? |
 | <code><a href="#cdk-sops-secrets.MultiStringParameterProps.property.flattenSeparator">flattenSeparator</a></code> | <code>string</code> | If the structure should be flattened use the provided separator between keys. |
 | <code><a href="#cdk-sops-secrets.MultiStringParameterProps.property.parameterKeyPrefix">parameterKeyPrefix</a></code> | <code>string</code> | Add this prefix to parameter names. |
-| <code><a href="#cdk-sops-secrets.MultiStringParameterProps.property.resourceType">resourceType</a></code> | <code><a href="#cdk-sops-secrets.ResourceType">ResourceType</a></code> | *No description.* |
 | <code><a href="#cdk-sops-secrets.MultiStringParameterProps.property.sopsAgeKey">sopsAgeKey</a></code> | <code>aws-cdk-lib.SecretValue</code> | The age key that should be used for encryption. |
 | <code><a href="#cdk-sops-secrets.MultiStringParameterProps.property.sopsFileFormat">sopsFileFormat</a></code> | <code>string</code> | The format of the sops file. |
 | <code><a href="#cdk-sops-secrets.MultiStringParameterProps.property.sopsFilePath">sopsFilePath</a></code> | <code>string</code> | The filepath to the sops file. |
@@ -1746,6 +1745,19 @@ const multiStringParameterProps: MultiStringParameterProps = { ... }
 
 ---
 
+##### `autoGenerateIamPermissions`<sup>Optional</sup> <a name="autoGenerateIamPermissions" id="cdk-sops-secrets.MultiStringParameterProps.property.autoGenerateIamPermissions"></a>
+
+```typescript
+public readonly autoGenerateIamPermissions: boolean;
+```
+
+- *Type:* boolean
+- *Default:* true
+
+Should this construct automatically create IAM permissions?
+
+---
+
 ##### `convertToJSON`<sup>Optional</sup> <a name="convertToJSON" id="cdk-sops-secrets.MultiStringParameterProps.property.convertToJSON"></a>
 
 ```typescript
@@ -1758,16 +1770,6 @@ public readonly convertToJSON: boolean;
 Should the encrypted sops value should be converted to JSON?
 
 Only JSON can be handled by cloud formations dynamic references.
-
----
-
-##### `creationType`<sup>Optional</sup> <a name="creationType" id="cdk-sops-secrets.MultiStringParameterProps.property.creationType"></a>
-
-```typescript
-public readonly creationType: CreationType;
-```
-
-- *Type:* <a href="#cdk-sops-secrets.CreationType">CreationType</a>
 
 ---
 
@@ -1810,16 +1812,6 @@ public readonly parameterKeyPrefix: string;
 - *Type:* string
 
 Add this prefix to parameter names.
-
----
-
-##### `resourceType`<sup>Optional</sup> <a name="resourceType" id="cdk-sops-secrets.MultiStringParameterProps.property.resourceType"></a>
-
-```typescript
-public readonly resourceType: ResourceType;
-```
-
-- *Type:* <a href="#cdk-sops-secrets.ResourceType">ResourceType</a>
 
 ---
 
@@ -2117,12 +2109,11 @@ const sopsSecretProps: SopsSecretProps = { ... }
 | <code><a href="#cdk-sops-secrets.SopsSecretProps.property.secretObjectValue">secretObjectValue</a></code> | <code>{[ key: string ]: aws-cdk-lib.SecretValue}</code> | Initial value for a JSON secret. |
 | <code><a href="#cdk-sops-secrets.SopsSecretProps.property.secretStringBeta1">secretStringBeta1</a></code> | <code>aws-cdk-lib.aws_secretsmanager.SecretStringValueBeta1</code> | Initial value for the secret. |
 | <code><a href="#cdk-sops-secrets.SopsSecretProps.property.secretStringValue">secretStringValue</a></code> | <code>aws-cdk-lib.SecretValue</code> | Initial value for the secret. |
+| <code><a href="#cdk-sops-secrets.SopsSecretProps.property.autoGenerateIamPermissions">autoGenerateIamPermissions</a></code> | <code>boolean</code> | Should this construct automatically create IAM permissions? |
 | <code><a href="#cdk-sops-secrets.SopsSecretProps.property.convertToJSON">convertToJSON</a></code> | <code>boolean</code> | Should the encrypted sops value should be converted to JSON? |
-| <code><a href="#cdk-sops-secrets.SopsSecretProps.property.creationType">creationType</a></code> | <code><a href="#cdk-sops-secrets.CreationType">CreationType</a></code> | *No description.* |
 | <code><a href="#cdk-sops-secrets.SopsSecretProps.property.flatten">flatten</a></code> | <code>boolean</code> | Should the structure be flattened? |
 | <code><a href="#cdk-sops-secrets.SopsSecretProps.property.flattenSeparator">flattenSeparator</a></code> | <code>string</code> | If the structure should be flattened use the provided separator between keys. |
 | <code><a href="#cdk-sops-secrets.SopsSecretProps.property.parameterKeyPrefix">parameterKeyPrefix</a></code> | <code>string</code> | Add this prefix to parameter names. |
-| <code><a href="#cdk-sops-secrets.SopsSecretProps.property.resourceType">resourceType</a></code> | <code><a href="#cdk-sops-secrets.ResourceType">ResourceType</a></code> | *No description.* |
 | <code><a href="#cdk-sops-secrets.SopsSecretProps.property.sopsAgeKey">sopsAgeKey</a></code> | <code>aws-cdk-lib.SecretValue</code> | The age key that should be used for encryption. |
 | <code><a href="#cdk-sops-secrets.SopsSecretProps.property.sopsFileFormat">sopsFileFormat</a></code> | <code>string</code> | The format of the sops file. |
 | <code><a href="#cdk-sops-secrets.SopsSecretProps.property.sopsFilePath">sopsFilePath</a></code> | <code>string</code> | The filepath to the sops file. |
@@ -2308,6 +2299,19 @@ Only one of `secretStringBeta1`, `secretStringValue`, 'secretObjectValue', and `
 
 ---
 
+##### `autoGenerateIamPermissions`<sup>Optional</sup> <a name="autoGenerateIamPermissions" id="cdk-sops-secrets.SopsSecretProps.property.autoGenerateIamPermissions"></a>
+
+```typescript
+public readonly autoGenerateIamPermissions: boolean;
+```
+
+- *Type:* boolean
+- *Default:* true
+
+Should this construct automatically create IAM permissions?
+
+---
+
 ##### `convertToJSON`<sup>Optional</sup> <a name="convertToJSON" id="cdk-sops-secrets.SopsSecretProps.property.convertToJSON"></a>
 
 ```typescript
@@ -2320,16 +2324,6 @@ public readonly convertToJSON: boolean;
 Should the encrypted sops value should be converted to JSON?
 
 Only JSON can be handled by cloud formations dynamic references.
-
----
-
-##### `creationType`<sup>Optional</sup> <a name="creationType" id="cdk-sops-secrets.SopsSecretProps.property.creationType"></a>
-
-```typescript
-public readonly creationType: CreationType;
-```
-
-- *Type:* <a href="#cdk-sops-secrets.CreationType">CreationType</a>
 
 ---
 
@@ -2372,16 +2366,6 @@ public readonly parameterKeyPrefix: string;
 - *Type:* string
 
 Add this prefix to parameter names.
-
----
-
-##### `resourceType`<sup>Optional</sup> <a name="resourceType" id="cdk-sops-secrets.SopsSecretProps.property.resourceType"></a>
-
-```typescript
-public readonly resourceType: ResourceType;
-```
-
-- *Type:* <a href="#cdk-sops-secrets.ResourceType">ResourceType</a>
 
 ---
 
@@ -2522,12 +2506,11 @@ const sopsStringParameterProps: SopsStringParameterProps = { ... }
 
 | **Name** | **Type** | **Description** |
 | --- | --- | --- |
+| <code><a href="#cdk-sops-secrets.SopsStringParameterProps.property.autoGenerateIamPermissions">autoGenerateIamPermissions</a></code> | <code>boolean</code> | Should this construct automatically create IAM permissions? |
 | <code><a href="#cdk-sops-secrets.SopsStringParameterProps.property.convertToJSON">convertToJSON</a></code> | <code>boolean</code> | Should the encrypted sops value should be converted to JSON? |
-| <code><a href="#cdk-sops-secrets.SopsStringParameterProps.property.creationType">creationType</a></code> | <code><a href="#cdk-sops-secrets.CreationType">CreationType</a></code> | *No description.* |
 | <code><a href="#cdk-sops-secrets.SopsStringParameterProps.property.flatten">flatten</a></code> | <code>boolean</code> | Should the structure be flattened? |
 | <code><a href="#cdk-sops-secrets.SopsStringParameterProps.property.flattenSeparator">flattenSeparator</a></code> | <code>string</code> | If the structure should be flattened use the provided separator between keys. |
 | <code><a href="#cdk-sops-secrets.SopsStringParameterProps.property.parameterKeyPrefix">parameterKeyPrefix</a></code> | <code>string</code> | Add this prefix to parameter names. |
-| <code><a href="#cdk-sops-secrets.SopsStringParameterProps.property.resourceType">resourceType</a></code> | <code><a href="#cdk-sops-secrets.ResourceType">ResourceType</a></code> | *No description.* |
 | <code><a href="#cdk-sops-secrets.SopsStringParameterProps.property.sopsAgeKey">sopsAgeKey</a></code> | <code>aws-cdk-lib.SecretValue</code> | The age key that should be used for encryption. |
 | <code><a href="#cdk-sops-secrets.SopsStringParameterProps.property.sopsFileFormat">sopsFileFormat</a></code> | <code>string</code> | The format of the sops file. |
 | <code><a href="#cdk-sops-secrets.SopsStringParameterProps.property.sopsFilePath">sopsFilePath</a></code> | <code>string</code> | The filepath to the sops file. |
@@ -2549,6 +2532,19 @@ const sopsStringParameterProps: SopsStringParameterProps = { ... }
 
 ---
 
+##### `autoGenerateIamPermissions`<sup>Optional</sup> <a name="autoGenerateIamPermissions" id="cdk-sops-secrets.SopsStringParameterProps.property.autoGenerateIamPermissions"></a>
+
+```typescript
+public readonly autoGenerateIamPermissions: boolean;
+```
+
+- *Type:* boolean
+- *Default:* true
+
+Should this construct automatically create IAM permissions?
+
+---
+
 ##### `convertToJSON`<sup>Optional</sup> <a name="convertToJSON" id="cdk-sops-secrets.SopsStringParameterProps.property.convertToJSON"></a>
 
 ```typescript
@@ -2561,16 +2557,6 @@ public readonly convertToJSON: boolean;
 Should the encrypted sops value should be converted to JSON?
 
 Only JSON can be handled by cloud formations dynamic references.
-
----
-
-##### `creationType`<sup>Optional</sup> <a name="creationType" id="cdk-sops-secrets.SopsStringParameterProps.property.creationType"></a>
-
-```typescript
-public readonly creationType: CreationType;
-```
-
-- *Type:* <a href="#cdk-sops-secrets.CreationType">CreationType</a>
 
 ---
 
@@ -2613,16 +2599,6 @@ public readonly parameterKeyPrefix: string;
 - *Type:* string
 
 Add this prefix to parameter names.
-
----
-
-##### `resourceType`<sup>Optional</sup> <a name="resourceType" id="cdk-sops-secrets.SopsStringParameterProps.property.resourceType"></a>
-
-```typescript
-public readonly resourceType: ResourceType;
-```
-
-- *Type:* <a href="#cdk-sops-secrets.ResourceType">ResourceType</a>
 
 ---
 
@@ -2891,12 +2867,11 @@ const sopsSyncOptions: SopsSyncOptions = { ... }
 
 | **Name** | **Type** | **Description** |
 | --- | --- | --- |
+| <code><a href="#cdk-sops-secrets.SopsSyncOptions.property.autoGenerateIamPermissions">autoGenerateIamPermissions</a></code> | <code>boolean</code> | Should this construct automatically create IAM permissions? |
 | <code><a href="#cdk-sops-secrets.SopsSyncOptions.property.convertToJSON">convertToJSON</a></code> | <code>boolean</code> | Should the encrypted sops value should be converted to JSON? |
-| <code><a href="#cdk-sops-secrets.SopsSyncOptions.property.creationType">creationType</a></code> | <code><a href="#cdk-sops-secrets.CreationType">CreationType</a></code> | *No description.* |
 | <code><a href="#cdk-sops-secrets.SopsSyncOptions.property.flatten">flatten</a></code> | <code>boolean</code> | Should the structure be flattened? |
 | <code><a href="#cdk-sops-secrets.SopsSyncOptions.property.flattenSeparator">flattenSeparator</a></code> | <code>string</code> | If the structure should be flattened use the provided separator between keys. |
 | <code><a href="#cdk-sops-secrets.SopsSyncOptions.property.parameterKeyPrefix">parameterKeyPrefix</a></code> | <code>string</code> | Add this prefix to parameter names. |
-| <code><a href="#cdk-sops-secrets.SopsSyncOptions.property.resourceType">resourceType</a></code> | <code><a href="#cdk-sops-secrets.ResourceType">ResourceType</a></code> | *No description.* |
 | <code><a href="#cdk-sops-secrets.SopsSyncOptions.property.sopsAgeKey">sopsAgeKey</a></code> | <code>aws-cdk-lib.SecretValue</code> | The age key that should be used for encryption. |
 | <code><a href="#cdk-sops-secrets.SopsSyncOptions.property.sopsFileFormat">sopsFileFormat</a></code> | <code>string</code> | The format of the sops file. |
 | <code><a href="#cdk-sops-secrets.SopsSyncOptions.property.sopsFilePath">sopsFilePath</a></code> | <code>string</code> | The filepath to the sops file. |
@@ -2906,6 +2881,19 @@ const sopsSyncOptions: SopsSyncOptions = { ... }
 | <code><a href="#cdk-sops-secrets.SopsSyncOptions.property.sopsS3Key">sopsS3Key</a></code> | <code>string</code> | If you want to pass the sops file via s3, you can specify the key inside the bucket you can use cfn parameter here Both, sopsS3Bucket and sopsS3Key have to be specified. |
 | <code><a href="#cdk-sops-secrets.SopsSyncOptions.property.stringifyValues">stringifyValues</a></code> | <code>boolean</code> | Shall all values be flattened? |
 | <code><a href="#cdk-sops-secrets.SopsSyncOptions.property.uploadType">uploadType</a></code> | <code><a href="#cdk-sops-secrets.UploadType">UploadType</a></code> | How should the secret be passed to the CustomResource? |
+
+---
+
+##### `autoGenerateIamPermissions`<sup>Optional</sup> <a name="autoGenerateIamPermissions" id="cdk-sops-secrets.SopsSyncOptions.property.autoGenerateIamPermissions"></a>
+
+```typescript
+public readonly autoGenerateIamPermissions: boolean;
+```
+
+- *Type:* boolean
+- *Default:* true
+
+Should this construct automatically create IAM permissions?
 
 ---
 
@@ -2921,16 +2909,6 @@ public readonly convertToJSON: boolean;
 Should the encrypted sops value should be converted to JSON?
 
 Only JSON can be handled by cloud formations dynamic references.
-
----
-
-##### `creationType`<sup>Optional</sup> <a name="creationType" id="cdk-sops-secrets.SopsSyncOptions.property.creationType"></a>
-
-```typescript
-public readonly creationType: CreationType;
-```
-
-- *Type:* <a href="#cdk-sops-secrets.CreationType">CreationType</a>
 
 ---
 
@@ -2973,16 +2951,6 @@ public readonly parameterKeyPrefix: string;
 - *Type:* string
 
 Add this prefix to parameter names.
-
----
-
-##### `resourceType`<sup>Optional</sup> <a name="resourceType" id="cdk-sops-secrets.SopsSyncOptions.property.resourceType"></a>
-
-```typescript
-public readonly resourceType: ResourceType;
-```
-
-- *Type:* <a href="#cdk-sops-secrets.ResourceType">ResourceType</a>
 
 ---
 
@@ -3109,7 +3077,7 @@ How should the secret be passed to the CustomResource?
 
 ### SopsSyncProps <a name="SopsSyncProps" id="cdk-sops-secrets.SopsSyncProps"></a>
 
-The configuration options extended by the target Secret.
+The configuration options extended by the target Secret / Parameter.
 
 #### Initializer <a name="Initializer" id="cdk-sops-secrets.SopsSyncProps.Initializer"></a>
 
@@ -3123,12 +3091,11 @@ const sopsSyncProps: SopsSyncProps = { ... }
 
 | **Name** | **Type** | **Description** |
 | --- | --- | --- |
+| <code><a href="#cdk-sops-secrets.SopsSyncProps.property.autoGenerateIamPermissions">autoGenerateIamPermissions</a></code> | <code>boolean</code> | Should this construct automatically create IAM permissions? |
 | <code><a href="#cdk-sops-secrets.SopsSyncProps.property.convertToJSON">convertToJSON</a></code> | <code>boolean</code> | Should the encrypted sops value should be converted to JSON? |
-| <code><a href="#cdk-sops-secrets.SopsSyncProps.property.creationType">creationType</a></code> | <code><a href="#cdk-sops-secrets.CreationType">CreationType</a></code> | *No description.* |
 | <code><a href="#cdk-sops-secrets.SopsSyncProps.property.flatten">flatten</a></code> | <code>boolean</code> | Should the structure be flattened? |
 | <code><a href="#cdk-sops-secrets.SopsSyncProps.property.flattenSeparator">flattenSeparator</a></code> | <code>string</code> | If the structure should be flattened use the provided separator between keys. |
 | <code><a href="#cdk-sops-secrets.SopsSyncProps.property.parameterKeyPrefix">parameterKeyPrefix</a></code> | <code>string</code> | Add this prefix to parameter names. |
-| <code><a href="#cdk-sops-secrets.SopsSyncProps.property.resourceType">resourceType</a></code> | <code><a href="#cdk-sops-secrets.ResourceType">ResourceType</a></code> | *No description.* |
 | <code><a href="#cdk-sops-secrets.SopsSyncProps.property.sopsAgeKey">sopsAgeKey</a></code> | <code>aws-cdk-lib.SecretValue</code> | The age key that should be used for encryption. |
 | <code><a href="#cdk-sops-secrets.SopsSyncProps.property.sopsFileFormat">sopsFileFormat</a></code> | <code>string</code> | The format of the sops file. |
 | <code><a href="#cdk-sops-secrets.SopsSyncProps.property.sopsFilePath">sopsFilePath</a></code> | <code>string</code> | The filepath to the sops file. |
@@ -3139,9 +3106,22 @@ const sopsSyncProps: SopsSyncProps = { ... }
 | <code><a href="#cdk-sops-secrets.SopsSyncProps.property.stringifyValues">stringifyValues</a></code> | <code>boolean</code> | Shall all values be flattened? |
 | <code><a href="#cdk-sops-secrets.SopsSyncProps.property.uploadType">uploadType</a></code> | <code><a href="#cdk-sops-secrets.UploadType">UploadType</a></code> | How should the secret be passed to the CustomResource? |
 | <code><a href="#cdk-sops-secrets.SopsSyncProps.property.encryptionKey">encryptionKey</a></code> | <code>aws-cdk-lib.aws_kms.IKey</code> | The encryption key used for encrypting the ssm parameter if `parameterName` is set. |
-| <code><a href="#cdk-sops-secrets.SopsSyncProps.property.parameterName">parameterName</a></code> | <code>string</code> | The parameter name. |
-| <code><a href="#cdk-sops-secrets.SopsSyncProps.property.parameterNames">parameterNames</a></code> | <code>string[]</code> | The parameter name. |
+| <code><a href="#cdk-sops-secrets.SopsSyncProps.property.parameterNames">parameterNames</a></code> | <code>string[]</code> | The parameter names. |
+| <code><a href="#cdk-sops-secrets.SopsSyncProps.property.resourceType">resourceType</a></code> | <code><a href="#cdk-sops-secrets.ResourceType">ResourceType</a></code> | Will this Sync deploy a Secret or Parameter(s). |
 | <code><a href="#cdk-sops-secrets.SopsSyncProps.property.secret">secret</a></code> | <code>aws-cdk-lib.aws_secretsmanager.ISecret</code> | The secret that will be populated with the encrypted sops file content. |
+
+---
+
+##### `autoGenerateIamPermissions`<sup>Optional</sup> <a name="autoGenerateIamPermissions" id="cdk-sops-secrets.SopsSyncProps.property.autoGenerateIamPermissions"></a>
+
+```typescript
+public readonly autoGenerateIamPermissions: boolean;
+```
+
+- *Type:* boolean
+- *Default:* true
+
+Should this construct automatically create IAM permissions?
 
 ---
 
@@ -3157,16 +3137,6 @@ public readonly convertToJSON: boolean;
 Should the encrypted sops value should be converted to JSON?
 
 Only JSON can be handled by cloud formations dynamic references.
-
----
-
-##### `creationType`<sup>Optional</sup> <a name="creationType" id="cdk-sops-secrets.SopsSyncProps.property.creationType"></a>
-
-```typescript
-public readonly creationType: CreationType;
-```
-
-- *Type:* <a href="#cdk-sops-secrets.CreationType">CreationType</a>
 
 ---
 
@@ -3209,16 +3179,6 @@ public readonly parameterKeyPrefix: string;
 - *Type:* string
 
 Add this prefix to parameter names.
-
----
-
-##### `resourceType`<sup>Optional</sup> <a name="resourceType" id="cdk-sops-secrets.SopsSyncProps.property.resourceType"></a>
-
-```typescript
-public readonly resourceType: ResourceType;
-```
-
-- *Type:* <a href="#cdk-sops-secrets.ResourceType">ResourceType</a>
 
 ---
 
@@ -3355,20 +3315,6 @@ The encryption key used for encrypting the ssm parameter if `parameterName` is s
 
 ---
 
-##### `parameterName`<sup>Optional</sup> <a name="parameterName" id="cdk-sops-secrets.SopsSyncProps.property.parameterName"></a>
-
-```typescript
-public readonly parameterName: string;
-```
-
-- *Type:* string
-
-The parameter name.
-
-If set this creates an encrypted SSM Parameter instead of a secret.
-
----
-
 ##### `parameterNames`<sup>Optional</sup> <a name="parameterNames" id="cdk-sops-secrets.SopsSyncProps.property.parameterNames"></a>
 
 ```typescript
@@ -3377,9 +3323,21 @@ public readonly parameterNames: string[];
 
 - *Type:* string[]
 
-The parameter name.
+The parameter names.
 
-If set this creates an encrypted SSM Parameter instead of a secret.
+If set this creates encrypted SSM Parameters instead of a secret.
+
+---
+
+##### `resourceType`<sup>Optional</sup> <a name="resourceType" id="cdk-sops-secrets.SopsSyncProps.property.resourceType"></a>
+
+```typescript
+public readonly resourceType: ResourceType;
+```
+
+- *Type:* <a href="#cdk-sops-secrets.ResourceType">ResourceType</a>
+
+Will this Sync deploy a Secret or Parameter(s).
 
 ---
 
@@ -3411,9 +3369,25 @@ const sopsSyncProviderProps: SopsSyncProviderProps = { ... }
 
 | **Name** | **Type** | **Description** |
 | --- | --- | --- |
+| <code><a href="#cdk-sops-secrets.SopsSyncProviderProps.property.role">role</a></code> | <code>aws-cdk-lib.aws_iam.IRole</code> | The role that should be used for the custom resource provider. |
 | <code><a href="#cdk-sops-secrets.SopsSyncProviderProps.property.securityGroups">securityGroups</a></code> | <code>aws-cdk-lib.aws_ec2.ISecurityGroup[]</code> | Only if `vpc` is supplied: The list of security groups to associate with the Lambda's network interfaces. |
 | <code><a href="#cdk-sops-secrets.SopsSyncProviderProps.property.vpc">vpc</a></code> | <code>aws-cdk-lib.aws_ec2.IVpc</code> | VPC network to place Lambda network interfaces. |
 | <code><a href="#cdk-sops-secrets.SopsSyncProviderProps.property.vpcSubnets">vpcSubnets</a></code> | <code>aws-cdk-lib.aws_ec2.SubnetSelection</code> | Where to place the network interfaces within the VPC. |
+
+---
+
+##### `role`<sup>Optional</sup> <a name="role" id="cdk-sops-secrets.SopsSyncProviderProps.property.role"></a>
+
+```typescript
+public readonly role: IRole;
+```
+
+- *Type:* aws-cdk-lib.aws_iam.IRole
+- *Default:* a new role will be created
+
+The role that should be used for the custom resource provider.
+
+If you don't specify any, a new role will be created with all required permissions
 
 ---
 
@@ -3460,31 +3434,6 @@ Where to place the network interfaces within the VPC.
 
 ## Enums <a name="Enums" id="Enums"></a>
 
-### CreationType <a name="CreationType" id="cdk-sops-secrets.CreationType"></a>
-
-#### Members <a name="Members" id="Members"></a>
-
-| **Name** | **Description** |
-| --- | --- |
-| <code><a href="#cdk-sops-secrets.CreationType.SINGLE">SINGLE</a></code> | Create or update a single secret/parameter. |
-| <code><a href="#cdk-sops-secrets.CreationType.MULTI">MULTI</a></code> | Create or update a multiple secrets/parameters by flattening the SOPS file. |
-
----
-
-##### `SINGLE` <a name="SINGLE" id="cdk-sops-secrets.CreationType.SINGLE"></a>
-
-Create or update a single secret/parameter.
-
----
-
-
-##### `MULTI` <a name="MULTI" id="cdk-sops-secrets.CreationType.MULTI"></a>
-
-Create or update a multiple secrets/parameters by flattening the SOPS file.
-
----
-
-
 ### ResourceType <a name="ResourceType" id="cdk-sops-secrets.ResourceType"></a>
 
 #### Members <a name="Members" id="Members"></a>
@@ -3493,6 +3442,7 @@ Create or update a multiple secrets/parameters by flattening the SOPS file.
 | --- | --- |
 | <code><a href="#cdk-sops-secrets.ResourceType.SECRET">SECRET</a></code> | *No description.* |
 | <code><a href="#cdk-sops-secrets.ResourceType.PARAMETER">PARAMETER</a></code> | *No description.* |
+| <code><a href="#cdk-sops-secrets.ResourceType.PARAMETER_MULTI">PARAMETER_MULTI</a></code> | *No description.* |
 
 ---
 
@@ -3502,6 +3452,11 @@ Create or update a multiple secrets/parameters by flattening the SOPS file.
 
 
 ##### `PARAMETER` <a name="PARAMETER" id="cdk-sops-secrets.ResourceType.PARAMETER"></a>
+
+---
+
+
+##### `PARAMETER_MULTI` <a name="PARAMETER_MULTI" id="cdk-sops-secrets.ResourceType.PARAMETER_MULTI"></a>
 
 ---
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -3,3 +3,25 @@
 Thanks for your interest in our project. Contributions are welcome. Feel free to [open an issue](issues) with questions or reporting ideas and bugs, or [open pull requests](pulls) to contribute code.
 
 We are committed to fostering a welcoming, respectful, and harassment-free environment. Be kind!
+
+## How to buidl/deploy local
+
+Install all necessary tools with `yarn install` and others manually like `go`
+
+Build the go Lambda code:
+```
+./scripts/build.sh
+```
+Build the package (for CDK development only the first `js` build has to complete):
+```
+yarn projen build
+```
+Link the package:
+```
+yarn link
+```
+Switch to the path/project where you would like to use cdk-sops-secrets. \
+Link the package to your local build source:
+```
+yarn link "cdk-sops-secrets"
+```

--- a/lambda/__snapshots__/handler_parameter_raw_test.snap
+++ b/lambda/__snapshots__/handler_parameter_raw_test.snap
@@ -3,7 +3,8 @@
 >>>S3ApiMockClient.GetObjectAttributes.Input
 {
   Bucket: "..",
-  Key: "../test-secrets/binary/sopsfile.enc-age.binary"
+  Key: "../test-secrets/binary/sopsfile.enc-age.binary",
+  ObjectAttributes: ["ETag"]
 }
 ---
 

--- a/lambda/__snapshots__/handler_parameter_yaml_multi_test.snap
+++ b/lambda/__snapshots__/handler_parameter_yaml_multi_test.snap
@@ -3,7 +3,8 @@
 >>>S3ApiMockClient.GetObjectAttributes.Input
 {
   Bucket: "..",
-  Key: "../test-secrets/yaml/sopsfile-complex-parameters.enc-age.yaml"
+  Key: "../test-secrets/yaml/sopsfile-complex-parameters.enc-age.yaml",
+  ObjectAttributes: ["ETag"]
 }
 ---
 
@@ -65,7 +66,8 @@ nil
 >>>S3ApiMockClient.GetObjectAttributes.Input
 {
   Bucket: "..",
-  Key: "../test-secrets/yaml/sopsfile-complex-parameters.enc-age.yaml"
+  Key: "../test-secrets/yaml/sopsfile-complex-parameters.enc-age.yaml",
+  ObjectAttributes: ["ETag"]
 }
 ---
 

--- a/lambda/__snapshots__/handler_secret_env_test.snap
+++ b/lambda/__snapshots__/handler_secret_env_test.snap
@@ -3,7 +3,8 @@
 >>>S3ApiMockClient.GetObjectAttributes.Input
 {
   Bucket: "..",
-  Key: "../test-secrets/dotenv/encrypted-best-secret.env"
+  Key: "../test-secrets/dotenv/encrypted-best-secret.env",
+  ObjectAttributes: ["ETag"]
 }
 ---
 
@@ -46,7 +47,8 @@ nil
 >>>S3ApiMockClient.GetObjectAttributes.Input
 {
   Bucket: "..",
-  Key: "../test-secrets/dotenv/encrypted-best-secret.env"
+  Key: "../test-secrets/dotenv/encrypted-best-secret.env",
+  ObjectAttributes: ["ETag"]
 }
 ---
 

--- a/lambda/__snapshots__/handler_secret_json_test.snap
+++ b/lambda/__snapshots__/handler_secret_json_test.snap
@@ -3,7 +3,8 @@
 >>>S3ApiMockClient.GetObjectAttributes.Input
 {
   Bucket: "..",
-  Key: "../test-secrets/json/sopsfile.enc-age.json"
+  Key: "../test-secrets/json/sopsfile.enc-age.json",
+  ObjectAttributes: ["ETag"]
 }
 ---
 
@@ -46,7 +47,8 @@ nil
 >>>S3ApiMockClient.GetObjectAttributes.Input
 {
   Bucket: "..",
-  Key: "../test-secrets/json/sopsfile-complex.enc-age.json"
+  Key: "../test-secrets/json/sopsfile-complex.enc-age.json",
+  ObjectAttributes: ["ETag"]
 }
 ---
 
@@ -89,7 +91,8 @@ nil
 >>>S3ApiMockClient.GetObjectAttributes.Input
 {
   Bucket: "..",
-  Key: "../test-secrets/json/sopsfile-complex.enc-age.json"
+  Key: "../test-secrets/json/sopsfile-complex.enc-age.json",
+  ObjectAttributes: ["ETag"]
 }
 ---
 
@@ -132,7 +135,8 @@ nil
 >>>S3ApiMockClient.GetObjectAttributes.Input
 {
   Bucket: "..",
-  Key: "../test-secrets/json/sopsfile-complex.enc-age.json"
+  Key: "../test-secrets/json/sopsfile-complex.enc-age.json",
+  ObjectAttributes: ["ETag"]
 }
 ---
 

--- a/lambda/__snapshots__/handler_secret_raw_test.snap
+++ b/lambda/__snapshots__/handler_secret_raw_test.snap
@@ -3,7 +3,8 @@
 >>>S3ApiMockClient.GetObjectAttributes.Input
 {
   Bucket: "..",
-  Key: "../test-secrets/binary/sopsfile.enc-age.binary"
+  Key: "../test-secrets/binary/sopsfile.enc-age.binary",
+  ObjectAttributes: ["ETag"]
 }
 ---
 

--- a/lambda/__snapshots__/handler_secret_yaml_test.snap
+++ b/lambda/__snapshots__/handler_secret_yaml_test.snap
@@ -3,7 +3,8 @@
 >>>S3ApiMockClient.GetObjectAttributes.Input
 {
   Bucket: "..",
-  Key: "../test-secrets/yaml/sopsfile.enc-age.yaml"
+  Key: "../test-secrets/yaml/sopsfile.enc-age.yaml",
+  ObjectAttributes: ["ETag"]
 }
 ---
 
@@ -46,7 +47,8 @@ nil
 >>>S3ApiMockClient.GetObjectAttributes.Input
 {
   Bucket: "..",
-  Key: "../test-secrets/yaml/sopsfile.enc-age.yaml"
+  Key: "../test-secrets/yaml/sopsfile.enc-age.yaml",
+  ObjectAttributes: ["ETag"]
 }
 ---
 
@@ -89,7 +91,8 @@ nil
 >>>S3ApiMockClient.GetObjectAttributes.Input
 {
   Bucket: "..",
-  Key: "../test-secrets/yaml/sopsfile-complex.enc-age.yaml"
+  Key: "../test-secrets/yaml/sopsfile-complex.enc-age.yaml",
+  ObjectAttributes: ["ETag"]
 }
 ---
 
@@ -132,7 +135,8 @@ nil
 >>>S3ApiMockClient.GetObjectAttributes.Input
 {
   Bucket: "..",
-  Key: "../test-secrets/yaml/sopsfile-complex.enc-age.yaml"
+  Key: "../test-secrets/yaml/sopsfile-complex.enc-age.yaml",
+  ObjectAttributes: ["ETag"]
 }
 ---
 
@@ -175,7 +179,8 @@ nil
 >>>S3ApiMockClient.GetObjectAttributes.Input
 {
   Bucket: "..",
-  Key: "../test-secrets/yaml/sopsfile-complex.enc-age.yaml"
+  Key: "../test-secrets/yaml/sopsfile-complex.enc-age.yaml",
+  ObjectAttributes: ["ETag"]
 }
 ---
 
@@ -218,7 +223,8 @@ nil
 >>>S3ApiMockClient.GetObjectAttributes.Input
 {
   Bucket: "..",
-  Key: "../test-secrets/yaml/sopsfile-complex.enc-age.yaml"
+  Key: "../test-secrets/yaml/sopsfile-complex.enc-age.yaml",
+  ObjectAttributes: ["ETag"]
 }
 ---
 
@@ -342,7 +348,8 @@ nil
 >>>S3ApiMockClient.GetObjectAttributes.Input
 {
   Bucket: "..",
-  Key: "../test-secrets/yaml/sopsfile-complex.enc-age.yaml"
+  Key: "../test-secrets/yaml/sopsfile-complex.enc-age.yaml",
+  ObjectAttributes: ["ETag"]
 }
 ---
 

--- a/lambda/events/event_create_s3_parameter_raw_simple.json
+++ b/lambda/events/event_create_s3_parameter_raw_simple.json
@@ -3,7 +3,6 @@
   "LogicalResourceId": "LogicalResourceId",
   "ResourceProperties": {
     "ResourceType": "PARAMETER",
-    "CreationType": "SINGLE",
     "ParameterName": "arn:aws:ssm:eu-central-1:123456789012:parameter/testsecret",
     "SopsS3File": {
       "Bucket": "..",

--- a/lambda/events/event_create_s3_parameter_yaml_complex.json
+++ b/lambda/events/event_create_s3_parameter_yaml_complex.json
@@ -2,8 +2,7 @@
   "RequestType": "Create",
   "LogicalResourceId": "LogicalResourceId",
   "ResourceProperties": {
-    "ResourceType": "PARAMETER",
-    "CreationType": "MULTI",
+    "ResourceType": "PARAMETER_MULTI",
     "ParameterName": "arn:aws:ssm:eu-central-1:123456789012:parameter/testsecret",
     "SopsS3File": {
       "Bucket": "..",

--- a/lambda/events/event_create_s3_parameter_yaml_complex_custom_keys.json
+++ b/lambda/events/event_create_s3_parameter_yaml_complex_custom_keys.json
@@ -2,8 +2,7 @@
   "RequestType": "Create",
   "LogicalResourceId": "LogicalResourceId",
   "ResourceProperties": {
-    "ResourceType": "PARAMETER",
-    "CreationType": "MULTI",
+    "ResourceType": "PARAMETER_MULTI",
     "ParameterName": "arn:aws:ssm:eu-central-1:123456789012:parameter/testsecret",
     "SopsS3File": {
       "Bucket": "..",

--- a/lambda/events/event_create_s3_secret_env_as_json_simple.json
+++ b/lambda/events/event_create_s3_secret_env_as_json_simple.json
@@ -3,7 +3,6 @@
   "LogicalResourceId": "LogicalResourceId",
   "ResourceProperties": {
     "ResourceType": "SECRET",
-    "CreationType": "SINGLE",
     "FlattenSeparator": ".",
     "SecretARN": "arn:aws:secretsmanager:eu-central-1:123456789012:secret:testsecret",
     "SopsS3File": {

--- a/lambda/events/event_create_s3_secret_env_simple.json
+++ b/lambda/events/event_create_s3_secret_env_simple.json
@@ -3,7 +3,6 @@
   "LogicalResourceId": "LogicalResourceId",
   "ResourceProperties": {
     "ResourceType": "SECRET",
-    "CreationType": "SINGLE",
     "FlattenSeparator": ".",
     "SecretARN": "arn:aws:secretsmanager:eu-central-1:123456789012:secret:testsecret",
     "SopsS3File": {

--- a/lambda/events/event_create_s3_secret_json_complex.json
+++ b/lambda/events/event_create_s3_secret_json_complex.json
@@ -3,7 +3,6 @@
   "LogicalResourceId": "LogicalResourceId",
   "ResourceProperties": {
     "ResourceType": "SECRET",
-    "CreationType": "SINGLE",
     "FlattenSeparator": ".",
     "SecretARN": "arn:aws:secretsmanager:eu-central-1:123456789012:secret:testsecret",
     "SopsS3File": {

--- a/lambda/events/event_create_s3_secret_json_complex_flat.json
+++ b/lambda/events/event_create_s3_secret_json_complex_flat.json
@@ -3,7 +3,6 @@
   "LogicalResourceId": "LogicalResourceId",
   "ResourceProperties": {
     "ResourceType": "SECRET",
-    "CreationType": "SINGLE",
     "FlattenSeparator": ".",
     "SecretARN": "arn:aws:secretsmanager:eu-central-1:123456789012:secret:testsecret",
     "SopsS3File": {

--- a/lambda/events/event_create_s3_secret_json_complex_stringify.json
+++ b/lambda/events/event_create_s3_secret_json_complex_stringify.json
@@ -3,7 +3,6 @@
   "LogicalResourceId": "LogicalResourceId",
   "ResourceProperties": {
     "ResourceType": "SECRET",
-    "CreationType": "SINGLE",
     "FlattenSeparator": ".",
     "SecretARN": "arn:aws:secretsmanager:eu-central-1:123456789012:secret:testsecret",
     "SopsS3File": {

--- a/lambda/events/event_create_s3_secret_json_simple.json
+++ b/lambda/events/event_create_s3_secret_json_simple.json
@@ -3,7 +3,6 @@
   "LogicalResourceId": "LogicalResourceId",
   "ResourceProperties": {
     "ResourceType": "SECRET",
-    "CreationType": "SINGLE",
     "FlattenSeparator": ".",
     "SecretARN": "arn:aws:secretsmanager:eu-central-1:123456789012:secret:testsecret",
     "SopsS3File": {

--- a/lambda/events/event_create_s3_secret_raw_simple.json
+++ b/lambda/events/event_create_s3_secret_raw_simple.json
@@ -3,7 +3,6 @@
   "LogicalResourceId": "LogicalResourceId",
   "ResourceProperties": {
     "ResourceType": "SECRET",
-    "CreationType": "SINGLE",
     "FlattenSeparator": ".",
     "SecretARN": "arn:aws:secretsmanager:eu-central-1:123456789012:secret:testsecret",
     "SopsS3File": {

--- a/lambda/events/event_create_s3_secret_yaml_as_json_complex.json
+++ b/lambda/events/event_create_s3_secret_yaml_as_json_complex.json
@@ -3,7 +3,6 @@
   "LogicalResourceId": "LogicalResourceId",
   "ResourceProperties": {
     "ResourceType": "SECRET",
-    "CreationType": "SINGLE",
     "FlattenSeparator": ".",
     "SecretARN": "arn:aws:secretsmanager:eu-central-1:123456789012:secret:testsecret",
     "SopsS3File": {

--- a/lambda/events/event_create_s3_secret_yaml_as_json_complex_flat.json
+++ b/lambda/events/event_create_s3_secret_yaml_as_json_complex_flat.json
@@ -3,7 +3,6 @@
   "LogicalResourceId": "LogicalResourceId",
   "ResourceProperties": {
     "ResourceType": "SECRET",
-    "CreationType": "SINGLE",
     "FlattenSeparator": ".",
     "SecretARN": "arn:aws:secretsmanager:eu-central-1:123456789012:secret:testsecret",
     "SopsS3File": {

--- a/lambda/events/event_create_s3_secret_yaml_as_json_simple.json
+++ b/lambda/events/event_create_s3_secret_yaml_as_json_simple.json
@@ -3,7 +3,6 @@
   "LogicalResourceId": "LogicalResourceId",
   "ResourceProperties": {
     "ResourceType": "SECRET",
-    "CreationType": "SINGLE",
     "FlattenSeparator": ".",
     "SecretARN": "arn:aws:secretsmanager:eu-central-1:123456789012:secret:testsecret",
     "SopsS3File": {

--- a/lambda/events/event_create_s3_secret_yaml_complex.json
+++ b/lambda/events/event_create_s3_secret_yaml_complex.json
@@ -3,7 +3,6 @@
   "LogicalResourceId": "LogicalResourceId",
   "ResourceProperties": {
     "ResourceType": "SECRET",
-    "CreationType": "SINGLE",
     "FlattenSeparator": ".",
     "SecretARN": "arn:aws:secretsmanager:eu-central-1:123456789012:secret:testsecret",
     "SopsS3File": {

--- a/lambda/events/event_create_s3_secret_yaml_complex_flat.json
+++ b/lambda/events/event_create_s3_secret_yaml_complex_flat.json
@@ -3,7 +3,6 @@
   "LogicalResourceId": "LogicalResourceId",
   "ResourceProperties": {
     "ResourceType": "SECRET",
-    "CreationType": "SINGLE",
     "FlattenSeparator": ".",
     "SecretARN": "arn:aws:secretsmanager:eu-central-1:123456789012:secret:testsecret",
     "SopsS3File": {

--- a/lambda/events/event_create_s3_secret_yaml_simple.json
+++ b/lambda/events/event_create_s3_secret_yaml_simple.json
@@ -3,7 +3,6 @@
   "LogicalResourceId": "LogicalResourceId",
   "ResourceProperties": {
     "ResourceType": "SECRET",
-    "CreationType": "SINGLE",
     "FlattenSeparator": ".",
     "SecretARN": "arn:aws:secretsmanager:eu-central-1:123456789012:secret:testsecret",
     "SopsS3File": {

--- a/lambda/main.go
+++ b/lambda/main.go
@@ -51,7 +51,6 @@ type SopsSyncResourcePropertys struct {
 	FlattenSeparator   string     `json:"FlattenSeparator,omitempty"`
 	ParameterKeyPrefix string     `json:"ParameterKeyPrefix,omitempty"`
 	StringifyValues    string     `json:"StringifyValues,omitempty"`
-	CreationType       string     `json:"CreationType,omitempty"`
 	ResourceType       string     `json:"ResourceType,omitempty"`
 }
 

--- a/lambda/main.go
+++ b/lambda/main.go
@@ -156,6 +156,9 @@ func (a AWS) syncSopsToSecretsmanager(ctx context.Context, event cfn.Event) (phy
 			attr, err := a.s3Api.GetObjectAttributes(&s3.GetObjectAttributesInput{
 				Bucket: &sopsFile.Bucket,
 				Key:    &sopsFile.Key,
+				ObjectAttributes: []*string{
+					aws.String("ETag"),
+				},
 			})
 			encryptedContent, err = a.getS3FileContent(sopsFile)
 			if err != nil {
@@ -347,6 +350,7 @@ func handleRequest(ctx context.Context, event cfn.Event) (physicalResourceID str
 		secretsmanager: secretsmanager.New(awsSession),
 		ssm:            ssm.New(awsSession),
 		s3Downloader:   s3manager.NewDownloader(awsSession),
+		s3Api:          s3.New(awsSession),
 	}
 	return a.syncSopsToSecretsmanager(ctx, event)
 }

--- a/scripts/lambda-build.sh
+++ b/scripts/lambda-build.sh
@@ -8,8 +8,8 @@ export GOPROXY=https://proxy.golang.org,direct
 export CGO_ENABLED=0
 go build -trimpath -buildvcs=false -tags lambda.norpc -o bootstrap -ldflags="-s -w -buildid="
 ls -la bootstrap
-shasum bootstrap
+sha1sum bootstrap
 touch -t 202002020000 bootstrap
 chmod 755 bootstrap
 ls -la bootstrap
-shasum bootstrap
+sha1sum bootstrap

--- a/src/MultiStringParameter.ts
+++ b/src/MultiStringParameter.ts
@@ -5,12 +5,7 @@ import { ResourceEnvironment, Stack } from 'aws-cdk-lib/core';
 import { Construct } from 'constructs';
 import * as YAML from 'yaml';
 import { SopsStringParameterProps } from './SopsStringParameter';
-import {
-  CreationType,
-  ResourceType,
-  SopsSync,
-  SopsSyncOptions,
-} from './SopsSync';
+import { ResourceType, SopsSync, SopsSyncOptions } from './SopsSync';
 
 interface JSONObject {
   [key: string]: any;
@@ -83,8 +78,7 @@ export class MultiStringParameter extends Construct {
 
     this.sync = new SopsSync(this, 'SopsSync', {
       encryptionKey: this.encryptionKey,
-      resourceType: ResourceType.PARAMETER,
-      creationType: CreationType.MULTI,
+      resourceType: ResourceType.PARAMETER_MULTI,
       flatten: true,
       flattenSeparator: this.keySeparator,
       parameterKeyPrefix: this.keyPrefix,

--- a/src/SopsSecret.ts
+++ b/src/SopsSecret.ts
@@ -20,12 +20,7 @@ import {
   Stack,
 } from 'aws-cdk-lib/core';
 import { Construct } from 'constructs';
-import {
-  CreationType,
-  ResourceType,
-  SopsSync,
-  SopsSyncOptions,
-} from './SopsSync';
+import { ResourceType, SopsSync, SopsSyncOptions } from './SopsSync';
 
 /**
  * The configuration options of the SopsSecret
@@ -63,7 +58,6 @@ export class SopsSecret extends Construct implements ISecret {
     this.sync = new SopsSync(this, 'SopsSync', {
       secret: this.secret,
       resourceType: ResourceType.SECRET,
-      creationType: CreationType.SINGLE,
       flattenSeparator: '.',
       ...(props as SopsSyncOptions),
     });

--- a/src/SopsStringParameter.ts
+++ b/src/SopsStringParameter.ts
@@ -7,7 +7,7 @@ import {
 } from 'aws-cdk-lib/aws-ssm';
 import { RemovalPolicy, ResourceEnvironment, Stack } from 'aws-cdk-lib/core';
 import { Construct } from 'constructs';
-import { SopsSync, SopsSyncOptions } from './SopsSync';
+import { ResourceType, SopsSync, SopsSyncOptions } from './SopsSync';
 
 /**
  * The configuration options of the StringParameter
@@ -58,7 +58,8 @@ export class SopsStringParameter extends Construct implements IStringParameter {
 
     this.sync = new SopsSync(this, 'SopsSync', {
       encryptionKey: this.parameter.encryptionKey,
-      parameterName: this.parameter.parameterName,
+      parameterNames: [this.parameter.parameterName],
+      resourceType: ResourceType.PARAMETER,
       ...(props as SopsSyncOptions),
     });
   }

--- a/src/SopsSync.ts
+++ b/src/SopsSync.ts
@@ -341,7 +341,12 @@ export class SopsSync extends Construct {
         }
       }
 
-      if (provider.role !== undefined && !props.autoGenerateIamPermissions) {
+      if (
+        // Is allways true, but to satisfy TS we check explicitly
+        provider.role !== undefined &&
+        // Check if user has disabled automatic generation
+        props.autoGenerateIamPermissions !== false
+      ) {
         Permissions.sopsKeys(this, {
           userDefinedKeys: props.sopsKmsKey,
           role: provider.role,

--- a/src/SopsSync.ts
+++ b/src/SopsSync.ts
@@ -33,20 +33,10 @@ export enum UploadType {
   ASSET = 'ASSET',
 }
 
-export enum CreationType {
-  /**
-   * Create or update a single secret/parameter
-   */
-  SINGLE = 'SINGLE',
-  /**
-   * Create or update a multiple secrets/parameters by flattening the SOPS file
-   */
-  MULTI = 'MULTI',
-}
-
 export enum ResourceType {
   SECRET = 'SECRET',
   PARAMETER = 'PARAMETER',
+  PARAMETER_MULTI = 'PARAMETER_MULTI',
 }
 
 /**
@@ -141,12 +131,16 @@ export interface SopsSyncOptions {
    */
   readonly stringifyValues?: boolean;
 
-  readonly creationType?: CreationType;
-  readonly resourceType?: ResourceType;
+  /**
+   * Should this construct automatically create IAM permissions?
+   *
+   * @default true
+   */
+  readonly autoGenerateIamPermissions?: boolean;
 }
 
 /**
- * The configuration options extended by the target Secret
+ * The configuration options extended by the target Secret / Parameter
  */
 export interface SopsSyncProps extends SopsSyncOptions {
   /**
@@ -155,12 +149,7 @@ export interface SopsSyncProps extends SopsSyncOptions {
   readonly secret?: ISecret;
 
   /**
-   * The parameter name. If set this creates an encrypted SSM Parameter instead of a secret.
-   */
-  readonly parameterName?: string;
-
-  /**
-   * The parameter name. If set this creates an encrypted SSM Parameter instead of a secret.
+   * The parameter names. If set this creates encrypted SSM Parameters instead of a secret.
    */
   readonly parameterNames?: string[];
 
@@ -168,6 +157,11 @@ export interface SopsSyncProps extends SopsSyncOptions {
    * The encryption key used for encrypting the ssm parameter if `parameterName` is set.
    */
   readonly encryptionKey?: IKey;
+
+  /**
+   * Will this Sync deploy a Secret or Parameter(s)
+   */
+  readonly resourceType?: ResourceType;
 }
 
 /**
@@ -192,6 +186,14 @@ export interface SopsSyncProviderProps {
    * @default - A dedicated security group will be created for the lambda function.
    */
   readonly securityGroups?: ISecurityGroup[];
+
+  /**
+   * The role that should be used for the custom resource provider.
+   * If you don't specify any, a new role will be created with all required permissions
+   *
+   * @default - a new role will be created
+   */
+  readonly role?: IRole;
 }
 
 export class SopsSyncProvider extends SingletonFunction implements IGrantable {
@@ -206,6 +208,7 @@ export class SopsSyncProvider extends SingletonFunction implements IGrantable {
       runtime: Runtime.PROVIDED_AL2,
       handler: 'bootstrap',
       uuid: 'SopsSyncProvider',
+      role: props?.role,
       timeout: Duration.seconds(60),
       environment: {
         SOPS_AGE_KEY: Lazy.string({
@@ -268,8 +271,11 @@ export class SopsSync extends Construct {
     let sopsS3File: { Bucket: string; Key: string } | undefined = undefined;
 
     if (
-      props.sopsFilePath !== undefined &&
-      (props.sopsS3Bucket !== undefined || props.sopsS3Key !== undefined)
+      (props.sopsFilePath == undefined &&
+        (props.sopsS3Bucket == undefined || props.sopsS3Key == undefined)) ||
+      (props.sopsFilePath !== undefined &&
+        props.sopsS3Bucket !== undefined &&
+        props.sopsS3Key !== undefined)
     ) {
       throw new Error(
         'You can either specify sopsFilePath or sopsS3Bucket and sopsS3Key!',
@@ -312,11 +318,12 @@ export class SopsSync extends Construct {
       if (!fs.existsSync(props.sopsFilePath)) {
         throw new Error(`File ${props.sopsFilePath} does not exist!`);
       }
+      const sopsFileContent = fs.readFileSync(props.sopsFilePath);
 
       switch (uploadType) {
         case UploadType.INLINE: {
           sopsInline = {
-            Content: fs.readFileSync(props.sopsFilePath).toString('base64'),
+            Content: sopsFileContent.toString('base64'),
             // We calculate the hash the same way as it would be done by new Asset(..) - so we can ensure stable version names even if switching from INLINE to ASSET and viceversa.
             Hash: FileSystem.fingerprint(props.sopsFilePath),
           };
@@ -334,71 +341,24 @@ export class SopsSync extends Construct {
         }
       }
 
-      if (provider.role !== undefined) {
-        if (props.sopsKmsKey !== undefined) {
-          props.sopsKmsKey.forEach((key) => key.grantDecrypt(provider.role!));
-        }
-        const fileContent = fs.readFileSync(props.sopsFilePath);
-        // Handle keys
-        const regexKey = /arn:aws:kms:[a-z0-9-]+:[\d]+:key\/[a-z0-9-]+/g;
-        const resultsKey = fileContent.toString().match(regexKey);
-        if (resultsKey !== undefined) {
-          resultsKey?.forEach((result, index) =>
-            Key.fromKeyArn(this, `SopsKey${index}`, result).grantDecrypt(
-              provider.role!,
-            ),
-          );
-        }
-        const regexAlias = /arn:aws:kms:[a-z0-9-]+:[\d]+:alias\/[a-z0-9-]+/g;
-        const resultsAlias = fileContent.toString().match(regexAlias);
-        if (resultsAlias !== undefined) {
-          resultsAlias?.forEach((result, index) =>
-            Key.fromLookup(this, `SopsAlias${index}`, {
-              aliasName: `alias/${result.split('/').slice(1).join('/')}`,
-            }).grantDecrypt(provider.role!),
-          );
-        }
-        if (props.secret) {
-          props.secret.grantWrite(provider);
-          props.secret.encryptionKey?.grantEncryptDecrypt(provider);
-          if (props.secret?.encryptionKey !== undefined) {
-            props.secret.encryptionKey.grantEncryptDecrypt(provider);
-          }
-        }
-        if (props.parameterName) {
-          provider.addToRolePolicy(
-            new PolicyStatement({
-              actions: ['ssm:PutParameter'],
-              resources: [
-                `arn:aws:ssm:${Stack.of(this).region}:${
-                  Stack.of(this).account
-                }:parameter${
-                  props.parameterName.startsWith('/')
-                    ? props.parameterName
-                    : `/${props.parameterName}`
-                }`,
-              ],
-            }),
-          );
-          props.encryptionKey?.grantEncryptDecrypt(provider);
-        }
-        if (props.parameterNames) {
-          this.createReducedParameterPolicy(
-            props.parameterNames,
-            provider.role,
-          );
-          props.encryptionKey?.grantEncryptDecrypt(provider);
-        }
-        if (sopsAsset !== undefined) {
-          sopsAsset.bucket.grantRead(provider);
-        }
+      if (provider.role !== undefined && !props.autoGenerateIamPermissions) {
+        Permissions.sopsKeys(this, {
+          userDefinedKeys: props.sopsKmsKey,
+          role: provider.role,
+          sopsFileContent: sopsFileContent.toString(),
+        });
+        Permissions.assetBucket(sopsAsset, provider.role);
+        Permissions.encryptionKey(props.encryptionKey, provider.role);
+        Permissions.secret(props.secret, provider.role);
+        Permissions.parameters(this, props.parameterNames, provider.role);
       } else {
         Annotations.of(this).addWarning(
-          `Please ensure proper permissions for the passed lambda function:\n  - write Access to the secret\n  - encrypt with the sopsKmsKey${
-            uploadType === UploadType.ASSET
-              ? '\n  - download from asset bucket'
-              : ''
-          }`,
+          [
+            'Please ensure proper permissions for the passed lambda function:',
+            '  - write Access to the secret/parameters',
+            '  - encrypt with the sopsKmsKey',
+            '  - download from asset bucket',
+          ].join('\n'),
         );
       }
       if (props.sopsAgeKey !== undefined) {
@@ -415,10 +375,6 @@ export class SopsSync extends Construct {
       uploadType = UploadType.ASSET;
       Annotations.of(this).addWarning(
         'You have to manually add permissions to the sops provider to (permission to download file, to decrypt sops file)!',
-      );
-    } else {
-      throw new Error(
-        'You have to specify both sopsS3Bucket and sopsS3Key or neither!',
       );
     }
 
@@ -439,90 +395,169 @@ export class SopsSync extends Construct {
         ParameterKeyPrefix: props.parameterKeyPrefix,
         Format: sopsFileFormat,
         StringifiedValues: this.stringifiedValues,
-        ParameterName: props.parameterName,
+        ParameterName:
+          // Dirty Workaround, refactor ...
+          props.parameterNames && props.parameterNames.length == 1
+            ? props.parameterNames[0]
+            : undefined,
         EncryptionKey:
           props.secret !== undefined ? undefined : props.encryptionKey?.keyId,
         ResourceType: props.resourceType
           ? props.resourceType.toString()
           : ResourceType.SECRET.toString(),
-        CreationType: props.creationType
-          ? props.creationType.toString()
-          : CreationType.SINGLE.toString(),
       },
     });
     this.versionId = cr.getAttString('VersionId');
   }
+}
 
-  private createReducedParameterPolicy(parameters: string[], role: IRole) {
-    // Avoid too large policies
-    // The maximum size of a managed policy is 6.144 bytes -> 1 character = 1 byte
-    const maxPolicyBytes = 6000; // Keep some bytes as a buffer
-    const arnPrefixBytes = 55; // Content for "arn:aws:ssm:ap-southeast-3:<accountnumer>:parameter/
-    let startAtParameter = 0;
-    let currentPolicyBytes = 300; // Reserve some byte space for basic stuff inside the policy
-    for (let i = 0; i < parameters.length; i += 1) {
-      if (
-        // Check if the current parameter would fit into the policy
-        arnPrefixBytes + parameters[i].length + currentPolicyBytes <
-        maxPolicyBytes
-      ) {
-        // If so increase the byte counter
-        currentPolicyBytes =
-          arnPrefixBytes + parameters[i].length + currentPolicyBytes;
-      } else {
-        const parameterNamesChunk = parameters.slice(
-          startAtParameter,
-          i, //end of slice is not included
-        );
-        startAtParameter = i;
-        currentPolicyBytes = 300;
-        // Create the policy for the selected chunk
-        const putPolicy = new ManagedPolicy(
-          this,
-          `SopsSecretParameterProviderManagedPolicyParameterAccess${i}`,
-          {
-            description:
-              'Policy to grant parameter provider permissions to put parameter',
-          },
-        );
-        putPolicy.addStatements(
-          new PolicyStatement({
-            actions: ['ssm:PutParameter'],
-            resources: parameterNamesChunk.map(
-              (param) =>
-                `arn:aws:ssm:${Stack.of(this).region}:${
-                  Stack.of(this).account
-                }:parameter${param.startsWith('/') ? param : `/${param}`}`,
-            ),
-          }),
-        );
-        role.addManagedPolicy(putPolicy);
-      }
+export namespace Permissions {
+  /**
+   * Grants the necessary permissions for encrypt/decrypt on the customer managed encryption key
+   * for the secrets / parameters.
+   */
+  export function encryptionKey(key: IKey | undefined, target: IGrantable) {
+    if (key === undefined) {
+      return;
     }
-    const parameterNamesChunk = parameters.slice(
-      startAtParameter,
-      parameters.length,
-    );
-    // Create the policy for the remaning elements
-    const putPolicy = new ManagedPolicy(
-      this,
-      `SopsSecretParameterProviderManagedPolicyParameterAccess${parameters.length}`,
-      {
-        description:
-          'Policy to grant parameter provider permissions to put parameter',
-      },
-    );
-    putPolicy.addStatements(
-      new PolicyStatement({
-        actions: ['ssm:PutParameter'],
-        resources: parameterNamesChunk.map(
-          (param) =>
-            `arn:aws:ssm:${Stack.of(this).region}:${
-              Stack.of(this).account
-            }:parameter${param.startsWith('/') ? param : `/${param}`}`,
-        ),
-      }),
-    );
-    role.addManagedPolicy(putPolicy);
+    key.grantEncryptDecrypt(target);
+  }
+
+  export function keysFromSopsContent(ctx: Construct, c: string): IKey[] {
+    const regexKey = /arn:aws:kms:[a-z0-9-]+:[\d]+:key\/[a-z0-9-]+/g;
+    const resultsKey = c.match(regexKey);
+    if (resultsKey !== null) {
+      return resultsKey.map((result, index) =>
+        Key.fromKeyArn(ctx, `SopsKey${index}`, result),
+      );
+    }
+    return [];
+  }
+
+  export function keysFromSopsContentAlias(ctx: Construct, c: string): IKey[] {
+    const regexAlias = /arn:aws:kms:[a-z0-9-]+:[\d]+:alias\/[a-z0-9-]+/g;
+    const resultsAlias = c.match(regexAlias);
+    if (resultsAlias !== null) {
+      return resultsAlias.map((result, index) =>
+        Key.fromLookup(ctx, `SopsAlias${index}`, {
+          aliasName: `alias/${result.split('/').slice(1).join('/')}`,
+        }),
+      );
+    }
+    return [];
+  }
+
+  /**
+   * Grants the necessary permissions to decrypt the given sops file content.
+   * Takes user defined keys, and searches the sops file for keys and aliases.
+   */
+  export function sopsKeys(
+    ctx: Construct,
+    props: {
+      userDefinedKeys?: IKey[];
+      sopsFileContent: string;
+      role: IRole;
+    },
+  ) {
+    (props.userDefinedKeys ?? [])
+      .concat(
+        keysFromSopsContent(ctx, props.sopsFileContent),
+        keysFromSopsContentAlias(ctx, props.sopsFileContent),
+      )
+      .forEach((key) => key.grantDecrypt(props.role));
+  }
+
+  /**
+   * Grants the necessary permissions to write the given secrets.
+   */
+  export function secret(
+    targetSecret: ISecret | undefined,
+    target: IGrantable,
+  ) {
+    if (targetSecret === undefined) {
+      return;
+    }
+    targetSecret.grantWrite(target);
+  }
+
+  function sliceParameters(params: string[]): string[][] {
+    const result: string[][] = [];
+    /**
+     * The maximum size of a managed policy is 6.144 bytes -> 1 character = 1 byte
+     * bout 300 characters are reserved for the policy apart from resource arns
+     * with some buffer, we end with an upper limit of 5750 bytes
+     */
+    const limit = 5750;
+
+    /**
+     * Content for "arn:aws:ssm:ap-southeast-3:<accountnumer>:parameter/
+     */
+    const prefix = 55;
+
+    let currentSize = 0;
+    let currentChunk: string[] = [];
+    for (const param of params) {
+      const paramLength = param.length + prefix;
+      if (currentSize + paramLength > limit) {
+        result.push(currentChunk);
+        currentChunk = [];
+        currentSize = 0;
+      }
+      currentChunk.push(param);
+      currentSize += paramLength;
+    }
+
+    if (currentChunk.length > 0) {
+      result.push(currentChunk);
+    }
+    return result;
+  }
+
+  /**
+   * Grants the necessary permissions to write the given parameters.
+   */
+  export function parameters(
+    ctx: Construct,
+    targetParameters: string[] | undefined,
+    role: IRole,
+  ) {
+    if (targetParameters === undefined) {
+      return;
+    }
+
+    const paramSlices = sliceParameters(targetParameters);
+
+    for (let i = 0; i < paramSlices.length; i++) {
+      const putPolicy = new ManagedPolicy(
+        ctx,
+        `SopsSecretParameterProviderManagedPolicyParameterAccess${i}`,
+        {
+          description:
+            'Policy to grant parameter provider permissions to put parameter',
+        },
+      );
+      putPolicy.addStatements(
+        new PolicyStatement({
+          actions: ['ssm:PutParameter'],
+          resources: paramSlices[i].map(
+            (param) =>
+              `arn:aws:ssm:${Stack.of(ctx).region}:${
+                Stack.of(ctx).account
+              }:parameter${param.startsWith('/') ? param : `/${param}`}`,
+          ),
+        }),
+      );
+      role.addManagedPolicy(putPolicy);
+    }
+  }
+
+  /**
+   * Grants the necessary permissions to read the given asset from S3.
+   */
+  export function assetBucket(asset: Asset | undefined, target: IGrantable) {
+    if (asset === undefined) {
+      return;
+    }
+    asset.bucket.grantRead(target);
   }
 }

--- a/test/__snapshots__/permissions.test.ts.snap
+++ b/test/__snapshots__/permissions.test.ts.snap
@@ -1,0 +1,62 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`parameters 1 parameter - full snapshot 1`] = `
+Object {
+  "SopsSecretParameterProviderManagedPolicyParameterAccess03C7CE5D3": Object {
+    "Properties": Object {
+      "Description": "Policy to grant parameter provider permissions to put parameter",
+      "Path": "/",
+      "PolicyDocument": Object {
+        "Statement": Array [
+          Object {
+            "Action": "ssm:PutParameter",
+            "Effect": "Allow",
+            "Resource": Object {
+              "Fn::Join": Array [
+                "",
+                Array [
+                  "arn:aws:ssm:",
+                  Object {
+                    "Ref": "AWS::Region",
+                  },
+                  ":",
+                  Object {
+                    "Ref": "AWS::AccountId",
+                  },
+                  ":parameter/parameter0",
+                ],
+              ],
+            },
+          },
+        ],
+        "Version": "2012-10-17",
+      },
+    },
+    "Type": "AWS::IAM::ManagedPolicy",
+  },
+}
+`;
+
+exports[`parameters 100 parameter - snapshot count 1`] = `
+Array [
+  "SopsSecretParameterProviderManagedPolicyParameterAccess03C7CE5D3",
+  "SopsSecretParameterProviderManagedPolicyParameterAccess1E27103A2",
+]
+`;
+
+exports[`parameters 1000 parameter - snapshot count 1`] = `
+Array [
+  "SopsSecretParameterProviderManagedPolicyParameterAccess03C7CE5D3",
+  "SopsSecretParameterProviderManagedPolicyParameterAccess1E27103A2",
+  "SopsSecretParameterProviderManagedPolicyParameterAccess204C56AEE",
+  "SopsSecretParameterProviderManagedPolicyParameterAccess39C2C7238",
+  "SopsSecretParameterProviderManagedPolicyParameterAccess4810168FC",
+  "SopsSecretParameterProviderManagedPolicyParameterAccess5A4020F4D",
+  "SopsSecretParameterProviderManagedPolicyParameterAccess6D18916A5",
+  "SopsSecretParameterProviderManagedPolicyParameterAccess7C1D2D5DD",
+  "SopsSecretParameterProviderManagedPolicyParameterAccess881B83B3B",
+  "SopsSecretParameterProviderManagedPolicyParameterAccess9F6C18C5F",
+  "SopsSecretParameterProviderManagedPolicyParameterAccess10B80D3BA8",
+  "SopsSecretParameterProviderManagedPolicyParameterAccess118D826D5D",
+]
+`;

--- a/test/permissions.test.ts
+++ b/test/permissions.test.ts
@@ -1,0 +1,58 @@
+import * as fs from 'fs';
+import path from 'path';
+import { Stack } from 'aws-cdk-lib';
+import { Permissions } from '../src/SopsSync';
+
+describe('keysFromSopsContent', () => {
+  let stack: Stack;
+
+  beforeEach(() => {
+    stack = new Stack();
+  });
+
+  test('returns an empty array when no keys are found', () => {
+    const content = 'no keys here';
+    const result = Permissions.keysFromSopsContent(stack, content);
+    expect(result).toEqual([]);
+  });
+
+  test('returns an array of IKey objects when keys are found', () => {
+    const content = fs
+      .readFileSync(
+        path.join(__dirname, '../test-secrets/yaml/sopsfile.enc-kms.yaml'),
+      )
+      .toString();
+    const result = Permissions.keysFromSopsContent(stack, content);
+    expect(result).toHaveLength(1);
+    expect(result[0].keyArn).toBe(
+      'arn:aws:kms:aws-region-1:123456789011:key/00000000-1234-4321-abcd-1234abcd12ab',
+    );
+    expect(result[0].keyId).toBe('00000000-1234-4321-abcd-1234abcd12ab');
+  });
+
+  test('returns multiple IKey objects when multiple keys are found', () => {
+    const content = fs
+      .readFileSync(
+        path.join(__dirname, '../test-secrets/yaml/sopsfile.enc-multikms.yaml'),
+      )
+      .toString();
+    const result = Permissions.keysFromSopsContent(stack, content);
+    expect(result).toHaveLength(4);
+    expect(result[0].keyArn).toBe(
+      'arn:aws:kms:aws-region-1:123456789011:key/00000000-1234-4321-abcd-1234abcd12ab',
+    );
+    expect(result[0].keyId).toBe('00000000-1234-4321-abcd-1234abcd12ab');
+    expect(result[1].keyArn).toBe(
+      'arn:aws:kms:aws-region-1:123456789011:key/00000001-1234-4321-abcd-1234abcd12ab',
+    );
+    expect(result[1].keyId).toBe('00000001-1234-4321-abcd-1234abcd12ab');
+    expect(result[2].keyArn).toBe(
+      'arn:aws:kms:aws-region-1:123456789011:key/00000002-1234-4321-abcd-1234abcd12ab',
+    );
+    expect(result[2].keyId).toBe('00000002-1234-4321-abcd-1234abcd12ab');
+    expect(result[3].keyArn).toBe(
+      'arn:aws:kms:aws-region-1:123456789011:key/00000003-1234-4321-abcd-1234abcd12ab',
+    );
+    expect(result[3].keyId).toBe('00000003-1234-4321-abcd-1234abcd12ab');
+  });
+});

--- a/test/permissions.test.ts
+++ b/test/permissions.test.ts
@@ -1,6 +1,9 @@
 import * as fs from 'fs';
 import path from 'path';
 import { Stack } from 'aws-cdk-lib';
+import { Template } from 'aws-cdk-lib/assertions';
+import { IRole, Role } from 'aws-cdk-lib/aws-iam';
+import { Key } from 'aws-cdk-lib/aws-kms';
 import { Permissions } from '../src/SopsSync';
 
 describe('keysFromSopsContent', () => {
@@ -54,5 +57,95 @@ describe('keysFromSopsContent', () => {
       'arn:aws:kms:aws-region-1:123456789011:key/00000003-1234-4321-abcd-1234abcd12ab',
     );
     expect(result[3].keyId).toBe('00000003-1234-4321-abcd-1234abcd12ab');
+  });
+});
+
+describe('keysFromSopsContentAlias', () => {
+  let stack: Stack;
+
+  beforeEach(() => {
+    stack = new Stack();
+  });
+
+  test('returns an empty array when no keys are found', () => {
+    const content = 'no keys here';
+    const result = Permissions.keysFromSopsContentAlias(stack, content);
+    expect(result).toEqual([]);
+  });
+
+  test('returns an array of IKey objects when keys are found', () => {
+    jest
+      .spyOn(Key, 'fromLookup')
+      .mockReturnValue(
+        Key.fromKeyArn(
+          stack,
+          'Key',
+          'arn:aws:kms:aws-region-1:123456789011:key/00000000-1234-4321-abcd-1234abcd12ab',
+        ),
+      );
+
+    const content = fs
+      .readFileSync(
+        path.join(
+          __dirname,
+          '../test-secrets/yaml/sopsfile.enc-kms-alias.yaml',
+        ),
+      )
+      .toString();
+    const result = Permissions.keysFromSopsContentAlias(stack, content);
+    expect(result[0].keyArn).toBe(
+      'arn:aws:kms:aws-region-1:123456789011:key/00000000-1234-4321-abcd-1234abcd12ab',
+    );
+    expect(result[0].keyId).toBe('00000000-1234-4321-abcd-1234abcd12ab');
+  });
+});
+
+describe('parameters', () => {
+  let stack: Stack;
+  let role: IRole;
+
+  beforeEach(() => {
+    stack = new Stack();
+    role = Role.fromRoleArn(
+      stack,
+      'TestRole',
+      'arn:aws:iam::123456789012:role/test-role',
+    );
+  });
+
+  function genParameters(prefix: string, count: number) {
+    const params: string[] = [];
+    for (let i = 0; i < count; i++) {
+      params.push(`${prefix}${i}`);
+    }
+    return params;
+  }
+
+  test('1 parameter - full snapshot', () => {
+    const params = genParameters('parameter', 1);
+    Permissions.parameters(stack, params, role);
+    expect(
+      Template.fromStack(stack).findResources('AWS::IAM::ManagedPolicy'),
+    ).toMatchSnapshot();
+  });
+
+  test('100 parameter - snapshot count', () => {
+    const params = genParameters('parameter', 100);
+    Permissions.parameters(stack, params, role);
+    expect(
+      Object.keys(
+        Template.fromStack(stack).findResources('AWS::IAM::ManagedPolicy'),
+      ),
+    ).toMatchSnapshot();
+  });
+
+  test('1000 parameter - snapshot count', () => {
+    const params = genParameters('parameter', 1000);
+    Permissions.parameters(stack, params, role);
+    expect(
+      Object.keys(
+        Template.fromStack(stack).findResources('AWS::IAM::ManagedPolicy'),
+      ),
+    ).toMatchSnapshot();
   });
 });

--- a/test/secret-asset.integ.snapshot/SecretIntegrationAsset.assets.json
+++ b/test/secret-asset.integ.snapshot/SecretIntegrationAsset.assets.json
@@ -1,15 +1,15 @@
 {
   "version": "36.0.0",
   "files": {
-    "bb705793a0bd8690a29d62191cd5ca3e4e0ebf81a9bf0a2677e8a30f841cafa2": {
+    "2c430c0ffff3fd5da4b853228c31f277ebb757a3e9a3f5e11321eb0cd8c91887": {
       "source": {
-        "path": "asset.bb705793a0bd8690a29d62191cd5ca3e4e0ebf81a9bf0a2677e8a30f841cafa2.zip",
+        "path": "asset.2c430c0ffff3fd5da4b853228c31f277ebb757a3e9a3f5e11321eb0cd8c91887.zip",
         "packaging": "file"
       },
       "destinations": {
         "current_account-current_region": {
           "bucketName": "cdk-hnb659fds-assets-${AWS::AccountId}-${AWS::Region}",
-          "objectKey": "bb705793a0bd8690a29d62191cd5ca3e4e0ebf81a9bf0a2677e8a30f841cafa2.zip",
+          "objectKey": "2c430c0ffff3fd5da4b853228c31f277ebb757a3e9a3f5e11321eb0cd8c91887.zip",
           "assumeRoleArn": "arn:${AWS::Partition}:iam::${AWS::AccountId}:role/cdk-hnb659fds-file-publishing-role-${AWS::AccountId}-${AWS::Region}"
         }
       }
@@ -79,7 +79,7 @@
         }
       }
     },
-    "76ae6b126c78a065078fae6c04e4062fb434dabe184b6f01cdff5d7c8b4b9610": {
+    "403db9f2066ea2fc6a72ec5211cda6589c0049fadd0dd5ea36461a810960d709": {
       "source": {
         "path": "SecretIntegrationAsset.template.json",
         "packaging": "file"
@@ -87,7 +87,7 @@
       "destinations": {
         "current_account-current_region": {
           "bucketName": "cdk-hnb659fds-assets-${AWS::AccountId}-${AWS::Region}",
-          "objectKey": "76ae6b126c78a065078fae6c04e4062fb434dabe184b6f01cdff5d7c8b4b9610.json",
+          "objectKey": "403db9f2066ea2fc6a72ec5211cda6589c0049fadd0dd5ea36461a810960d709.json",
           "assumeRoleArn": "arn:${AWS::Partition}:iam::${AWS::AccountId}:role/cdk-hnb659fds-file-publishing-role-${AWS::AccountId}-${AWS::Region}"
         }
       }

--- a/test/secret-asset.integ.snapshot/SecretIntegrationAsset.assets.json
+++ b/test/secret-asset.integ.snapshot/SecretIntegrationAsset.assets.json
@@ -1,15 +1,15 @@
 {
   "version": "36.0.0",
   "files": {
-    "3b70dd74522545fd1512f35f09eee7be6b317571aa28afc14540a494b3e5c4ee": {
+    "bb705793a0bd8690a29d62191cd5ca3e4e0ebf81a9bf0a2677e8a30f841cafa2": {
       "source": {
-        "path": "asset.3b70dd74522545fd1512f35f09eee7be6b317571aa28afc14540a494b3e5c4ee.zip",
+        "path": "asset.bb705793a0bd8690a29d62191cd5ca3e4e0ebf81a9bf0a2677e8a30f841cafa2.zip",
         "packaging": "file"
       },
       "destinations": {
         "current_account-current_region": {
           "bucketName": "cdk-hnb659fds-assets-${AWS::AccountId}-${AWS::Region}",
-          "objectKey": "3b70dd74522545fd1512f35f09eee7be6b317571aa28afc14540a494b3e5c4ee.zip",
+          "objectKey": "bb705793a0bd8690a29d62191cd5ca3e4e0ebf81a9bf0a2677e8a30f841cafa2.zip",
           "assumeRoleArn": "arn:${AWS::Partition}:iam::${AWS::AccountId}:role/cdk-hnb659fds-file-publishing-role-${AWS::AccountId}-${AWS::Region}"
         }
       }
@@ -79,7 +79,7 @@
         }
       }
     },
-    "ee003947bd7743f60ea9e9f3107b58b66df0259acd6bc9d131615a1fa10a8429": {
+    "76ae6b126c78a065078fae6c04e4062fb434dabe184b6f01cdff5d7c8b4b9610": {
       "source": {
         "path": "SecretIntegrationAsset.template.json",
         "packaging": "file"
@@ -87,7 +87,7 @@
       "destinations": {
         "current_account-current_region": {
           "bucketName": "cdk-hnb659fds-assets-${AWS::AccountId}-${AWS::Region}",
-          "objectKey": "ee003947bd7743f60ea9e9f3107b58b66df0259acd6bc9d131615a1fa10a8429.json",
+          "objectKey": "76ae6b126c78a065078fae6c04e4062fb434dabe184b6f01cdff5d7c8b4b9610.json",
           "assumeRoleArn": "arn:${AWS::Partition}:iam::${AWS::AccountId}:role/cdk-hnb659fds-file-publishing-role-${AWS::AccountId}-${AWS::Region}"
         }
       }

--- a/test/secret-asset.integ.snapshot/SecretIntegrationAsset.assets.json
+++ b/test/secret-asset.integ.snapshot/SecretIntegrationAsset.assets.json
@@ -1,15 +1,15 @@
 {
   "version": "36.0.0",
   "files": {
-    "b84f4ae044484433485a09ba2d15bdd1cd134698fecd0af024e8a36b2c001d92": {
+    "3b70dd74522545fd1512f35f09eee7be6b317571aa28afc14540a494b3e5c4ee": {
       "source": {
-        "path": "asset.b84f4ae044484433485a09ba2d15bdd1cd134698fecd0af024e8a36b2c001d92.zip",
+        "path": "asset.3b70dd74522545fd1512f35f09eee7be6b317571aa28afc14540a494b3e5c4ee.zip",
         "packaging": "file"
       },
       "destinations": {
         "current_account-current_region": {
           "bucketName": "cdk-hnb659fds-assets-${AWS::AccountId}-${AWS::Region}",
-          "objectKey": "b84f4ae044484433485a09ba2d15bdd1cd134698fecd0af024e8a36b2c001d92.zip",
+          "objectKey": "3b70dd74522545fd1512f35f09eee7be6b317571aa28afc14540a494b3e5c4ee.zip",
           "assumeRoleArn": "arn:${AWS::Partition}:iam::${AWS::AccountId}:role/cdk-hnb659fds-file-publishing-role-${AWS::AccountId}-${AWS::Region}"
         }
       }
@@ -79,7 +79,7 @@
         }
       }
     },
-    "e363e1c42928a35c199fd17c68fdac2df3407feb9216f8cdf1511a609a2b0f72": {
+    "ee003947bd7743f60ea9e9f3107b58b66df0259acd6bc9d131615a1fa10a8429": {
       "source": {
         "path": "SecretIntegrationAsset.template.json",
         "packaging": "file"
@@ -87,7 +87,7 @@
       "destinations": {
         "current_account-current_region": {
           "bucketName": "cdk-hnb659fds-assets-${AWS::AccountId}-${AWS::Region}",
-          "objectKey": "e363e1c42928a35c199fd17c68fdac2df3407feb9216f8cdf1511a609a2b0f72.json",
+          "objectKey": "ee003947bd7743f60ea9e9f3107b58b66df0259acd6bc9d131615a1fa10a8429.json",
           "assumeRoleArn": "arn:${AWS::Partition}:iam::${AWS::AccountId}:role/cdk-hnb659fds-file-publishing-role-${AWS::AccountId}-${AWS::Region}"
         }
       }

--- a/test/secret-asset.integ.snapshot/SecretIntegrationAsset.template.json
+++ b/test/secret-asset.integ.snapshot/SecretIntegrationAsset.template.json
@@ -231,7 +231,7 @@
      "S3Bucket": {
       "Fn::Sub": "cdk-hnb659fds-assets-${AWS::AccountId}-${AWS::Region}"
      },
-     "S3Key": "3b70dd74522545fd1512f35f09eee7be6b317571aa28afc14540a494b3e5c4ee.zip"
+     "S3Key": "bb705793a0bd8690a29d62191cd5ca3e4e0ebf81a9bf0a2677e8a30f841cafa2.zip"
     },
     "Environment": {
      "Variables": {

--- a/test/secret-asset.integ.snapshot/SecretIntegrationAsset.template.json
+++ b/test/secret-asset.integ.snapshot/SecretIntegrationAsset.template.json
@@ -231,7 +231,7 @@
      "S3Bucket": {
       "Fn::Sub": "cdk-hnb659fds-assets-${AWS::AccountId}-${AWS::Region}"
      },
-     "S3Key": "bb705793a0bd8690a29d62191cd5ca3e4e0ebf81a9bf0a2677e8a30f841cafa2.zip"
+     "S3Key": "2c430c0ffff3fd5da4b853228c31f277ebb757a3e9a3f5e11321eb0cd8c91887.zip"
     },
     "Environment": {
      "Variables": {

--- a/test/secret-asset.integ.snapshot/SecretIntegrationAsset.template.json
+++ b/test/secret-asset.integ.snapshot/SecretIntegrationAsset.template.json
@@ -31,8 +31,7 @@
     "FlattenSeparator": ".",
     "Format": "json",
     "StringifiedValues": true,
-    "ResourceType": "SECRET",
-    "CreationType": "SINGLE"
+    "ResourceType": "SECRET"
    },
    "UpdateReplacePolicy": "Delete",
    "DeletionPolicy": "Delete"
@@ -75,16 +74,6 @@
      "Statement": [
       {
        "Action": [
-        "secretsmanager:PutSecretValue",
-        "secretsmanager:UpdateSecret"
-       ],
-       "Effect": "Allow",
-       "Resource": {
-        "Ref": "SopsSecretJSON72040543"
-       }
-      },
-      {
-       "Action": [
         "s3:GetObject*",
         "s3:GetBucket*",
         "s3:List*"
@@ -123,6 +112,16 @@
          ]
         }
        ]
+      },
+      {
+       "Action": [
+        "secretsmanager:PutSecretValue",
+        "secretsmanager:UpdateSecret"
+       ],
+       "Effect": "Allow",
+       "Resource": {
+        "Ref": "SopsSecretJSON72040543"
+       }
       },
       {
        "Action": [
@@ -232,7 +231,7 @@
      "S3Bucket": {
       "Fn::Sub": "cdk-hnb659fds-assets-${AWS::AccountId}-${AWS::Region}"
      },
-     "S3Key": "b84f4ae044484433485a09ba2d15bdd1cd134698fecd0af024e8a36b2c001d92.zip"
+     "S3Key": "3b70dd74522545fd1512f35f09eee7be6b317571aa28afc14540a494b3e5c4ee.zip"
     },
     "Environment": {
      "Variables": {
@@ -285,8 +284,7 @@
     "FlattenSeparator": ".",
     "Format": "yaml",
     "StringifiedValues": true,
-    "ResourceType": "SECRET",
-    "CreationType": "SINGLE"
+    "ResourceType": "SECRET"
    },
    "UpdateReplacePolicy": "Delete",
    "DeletionPolicy": "Delete"
@@ -322,8 +320,7 @@
     "FlattenSeparator": ".",
     "Format": "yaml",
     "StringifiedValues": true,
-    "ResourceType": "SECRET",
-    "CreationType": "SINGLE"
+    "ResourceType": "SECRET"
    },
    "UpdateReplacePolicy": "Delete",
    "DeletionPolicy": "Delete"
@@ -359,8 +356,7 @@
     "FlattenSeparator": ".",
     "Format": "json",
     "StringifiedValues": true,
-    "ResourceType": "SECRET",
-    "CreationType": "SINGLE"
+    "ResourceType": "SECRET"
    },
    "UpdateReplacePolicy": "Delete",
    "DeletionPolicy": "Delete"
@@ -396,8 +392,7 @@
     "FlattenSeparator": ".",
     "Format": "json",
     "StringifiedValues": true,
-    "ResourceType": "SECRET",
-    "CreationType": "SINGLE"
+    "ResourceType": "SECRET"
    },
    "UpdateReplacePolicy": "Delete",
    "DeletionPolicy": "Delete"
@@ -433,8 +428,7 @@
     "FlattenSeparator": ".",
     "Format": "yaml",
     "StringifiedValues": true,
-    "ResourceType": "SECRET",
-    "CreationType": "SINGLE"
+    "ResourceType": "SECRET"
    },
    "UpdateReplacePolicy": "Delete",
    "DeletionPolicy": "Delete"
@@ -470,8 +464,7 @@
     "FlattenSeparator": ".",
     "Format": "yaml",
     "StringifiedValues": true,
-    "ResourceType": "SECRET",
-    "CreationType": "SINGLE"
+    "ResourceType": "SECRET"
    },
    "UpdateReplacePolicy": "Delete",
    "DeletionPolicy": "Delete"
@@ -507,8 +500,7 @@
     "FlattenSeparator": ".",
     "Format": "yaml",
     "StringifiedValues": true,
-    "ResourceType": "SECRET",
-    "CreationType": "SINGLE"
+    "ResourceType": "SECRET"
    },
    "UpdateReplacePolicy": "Delete",
    "DeletionPolicy": "Delete"
@@ -544,8 +536,7 @@
     "FlattenSeparator": ".",
     "Format": "yaml",
     "StringifiedValues": true,
-    "ResourceType": "SECRET",
-    "CreationType": "SINGLE"
+    "ResourceType": "SECRET"
    },
    "UpdateReplacePolicy": "Delete",
    "DeletionPolicy": "Delete"
@@ -581,8 +572,7 @@
     "FlattenSeparator": ".",
     "Format": "binary",
     "StringifiedValues": true,
-    "ResourceType": "SECRET",
-    "CreationType": "SINGLE"
+    "ResourceType": "SECRET"
    },
    "UpdateReplacePolicy": "Delete",
    "DeletionPolicy": "Delete"

--- a/test/secret-inline.integ.snapshot/SecretIntegrationInline.assets.json
+++ b/test/secret-inline.integ.snapshot/SecretIntegrationInline.assets.json
@@ -1,20 +1,20 @@
 {
   "version": "36.0.0",
   "files": {
-    "3b70dd74522545fd1512f35f09eee7be6b317571aa28afc14540a494b3e5c4ee": {
+    "bb705793a0bd8690a29d62191cd5ca3e4e0ebf81a9bf0a2677e8a30f841cafa2": {
       "source": {
-        "path": "asset.3b70dd74522545fd1512f35f09eee7be6b317571aa28afc14540a494b3e5c4ee.zip",
+        "path": "asset.bb705793a0bd8690a29d62191cd5ca3e4e0ebf81a9bf0a2677e8a30f841cafa2.zip",
         "packaging": "file"
       },
       "destinations": {
         "current_account-current_region": {
           "bucketName": "cdk-hnb659fds-assets-${AWS::AccountId}-${AWS::Region}",
-          "objectKey": "3b70dd74522545fd1512f35f09eee7be6b317571aa28afc14540a494b3e5c4ee.zip",
+          "objectKey": "bb705793a0bd8690a29d62191cd5ca3e4e0ebf81a9bf0a2677e8a30f841cafa2.zip",
           "assumeRoleArn": "arn:${AWS::Partition}:iam::${AWS::AccountId}:role/cdk-hnb659fds-file-publishing-role-${AWS::AccountId}-${AWS::Region}"
         }
       }
     },
-    "5a5e753daa5d4633ab32a983522828d7452f745cc537f206a8e7d375994fcb64": {
+    "0c5708f02afd19879e2de4293a656e79dc61639b3e2eb0a318efc0984b4f6cf2": {
       "source": {
         "path": "SecretIntegrationInline.template.json",
         "packaging": "file"
@@ -22,7 +22,7 @@
       "destinations": {
         "current_account-current_region": {
           "bucketName": "cdk-hnb659fds-assets-${AWS::AccountId}-${AWS::Region}",
-          "objectKey": "5a5e753daa5d4633ab32a983522828d7452f745cc537f206a8e7d375994fcb64.json",
+          "objectKey": "0c5708f02afd19879e2de4293a656e79dc61639b3e2eb0a318efc0984b4f6cf2.json",
           "assumeRoleArn": "arn:${AWS::Partition}:iam::${AWS::AccountId}:role/cdk-hnb659fds-file-publishing-role-${AWS::AccountId}-${AWS::Region}"
         }
       }

--- a/test/secret-inline.integ.snapshot/SecretIntegrationInline.assets.json
+++ b/test/secret-inline.integ.snapshot/SecretIntegrationInline.assets.json
@@ -1,20 +1,20 @@
 {
   "version": "36.0.0",
   "files": {
-    "b84f4ae044484433485a09ba2d15bdd1cd134698fecd0af024e8a36b2c001d92": {
+    "3b70dd74522545fd1512f35f09eee7be6b317571aa28afc14540a494b3e5c4ee": {
       "source": {
-        "path": "asset.b84f4ae044484433485a09ba2d15bdd1cd134698fecd0af024e8a36b2c001d92.zip",
+        "path": "asset.3b70dd74522545fd1512f35f09eee7be6b317571aa28afc14540a494b3e5c4ee.zip",
         "packaging": "file"
       },
       "destinations": {
         "current_account-current_region": {
           "bucketName": "cdk-hnb659fds-assets-${AWS::AccountId}-${AWS::Region}",
-          "objectKey": "b84f4ae044484433485a09ba2d15bdd1cd134698fecd0af024e8a36b2c001d92.zip",
+          "objectKey": "3b70dd74522545fd1512f35f09eee7be6b317571aa28afc14540a494b3e5c4ee.zip",
           "assumeRoleArn": "arn:${AWS::Partition}:iam::${AWS::AccountId}:role/cdk-hnb659fds-file-publishing-role-${AWS::AccountId}-${AWS::Region}"
         }
       }
     },
-    "3dcfa0a64e513705636a673bbca1b4c1ca9804d58579498b3479f581295035fa": {
+    "5a5e753daa5d4633ab32a983522828d7452f745cc537f206a8e7d375994fcb64": {
       "source": {
         "path": "SecretIntegrationInline.template.json",
         "packaging": "file"
@@ -22,7 +22,7 @@
       "destinations": {
         "current_account-current_region": {
           "bucketName": "cdk-hnb659fds-assets-${AWS::AccountId}-${AWS::Region}",
-          "objectKey": "3dcfa0a64e513705636a673bbca1b4c1ca9804d58579498b3479f581295035fa.json",
+          "objectKey": "5a5e753daa5d4633ab32a983522828d7452f745cc537f206a8e7d375994fcb64.json",
           "assumeRoleArn": "arn:${AWS::Partition}:iam::${AWS::AccountId}:role/cdk-hnb659fds-file-publishing-role-${AWS::AccountId}-${AWS::Region}"
         }
       }

--- a/test/secret-inline.integ.snapshot/SecretIntegrationInline.assets.json
+++ b/test/secret-inline.integ.snapshot/SecretIntegrationInline.assets.json
@@ -1,20 +1,20 @@
 {
   "version": "36.0.0",
   "files": {
-    "bb705793a0bd8690a29d62191cd5ca3e4e0ebf81a9bf0a2677e8a30f841cafa2": {
+    "2c430c0ffff3fd5da4b853228c31f277ebb757a3e9a3f5e11321eb0cd8c91887": {
       "source": {
-        "path": "asset.bb705793a0bd8690a29d62191cd5ca3e4e0ebf81a9bf0a2677e8a30f841cafa2.zip",
+        "path": "asset.2c430c0ffff3fd5da4b853228c31f277ebb757a3e9a3f5e11321eb0cd8c91887.zip",
         "packaging": "file"
       },
       "destinations": {
         "current_account-current_region": {
           "bucketName": "cdk-hnb659fds-assets-${AWS::AccountId}-${AWS::Region}",
-          "objectKey": "bb705793a0bd8690a29d62191cd5ca3e4e0ebf81a9bf0a2677e8a30f841cafa2.zip",
+          "objectKey": "2c430c0ffff3fd5da4b853228c31f277ebb757a3e9a3f5e11321eb0cd8c91887.zip",
           "assumeRoleArn": "arn:${AWS::Partition}:iam::${AWS::AccountId}:role/cdk-hnb659fds-file-publishing-role-${AWS::AccountId}-${AWS::Region}"
         }
       }
     },
-    "0c5708f02afd19879e2de4293a656e79dc61639b3e2eb0a318efc0984b4f6cf2": {
+    "55aa34bad424010bf095d40fbfbbd4b7250f7c373c25a117c203aa788214e7a3": {
       "source": {
         "path": "SecretIntegrationInline.template.json",
         "packaging": "file"
@@ -22,7 +22,7 @@
       "destinations": {
         "current_account-current_region": {
           "bucketName": "cdk-hnb659fds-assets-${AWS::AccountId}-${AWS::Region}",
-          "objectKey": "0c5708f02afd19879e2de4293a656e79dc61639b3e2eb0a318efc0984b4f6cf2.json",
+          "objectKey": "55aa34bad424010bf095d40fbfbbd4b7250f7c373c25a117c203aa788214e7a3.json",
           "assumeRoleArn": "arn:${AWS::Partition}:iam::${AWS::AccountId}:role/cdk-hnb659fds-file-publishing-role-${AWS::AccountId}-${AWS::Region}"
         }
       }

--- a/test/secret-inline.integ.snapshot/SecretIntegrationInline.template.json
+++ b/test/secret-inline.integ.snapshot/SecretIntegrationInline.template.json
@@ -29,8 +29,7 @@
     "FlattenSeparator": ".",
     "Format": "json",
     "StringifiedValues": true,
-    "ResourceType": "SECRET",
-    "CreationType": "SINGLE"
+    "ResourceType": "SECRET"
    },
    "UpdateReplacePolicy": "Delete",
    "DeletionPolicy": "Delete"
@@ -199,7 +198,7 @@
      "S3Bucket": {
       "Fn::Sub": "cdk-hnb659fds-assets-${AWS::AccountId}-${AWS::Region}"
      },
-     "S3Key": "b84f4ae044484433485a09ba2d15bdd1cd134698fecd0af024e8a36b2c001d92.zip"
+     "S3Key": "3b70dd74522545fd1512f35f09eee7be6b317571aa28afc14540a494b3e5c4ee.zip"
     },
     "Environment": {
      "Variables": {
@@ -250,8 +249,7 @@
     "FlattenSeparator": ".",
     "Format": "yaml",
     "StringifiedValues": true,
-    "ResourceType": "SECRET",
-    "CreationType": "SINGLE"
+    "ResourceType": "SECRET"
    },
    "UpdateReplacePolicy": "Delete",
    "DeletionPolicy": "Delete"
@@ -285,8 +283,7 @@
     "FlattenSeparator": ".",
     "Format": "yaml",
     "StringifiedValues": true,
-    "ResourceType": "SECRET",
-    "CreationType": "SINGLE"
+    "ResourceType": "SECRET"
    },
    "UpdateReplacePolicy": "Delete",
    "DeletionPolicy": "Delete"
@@ -320,8 +317,7 @@
     "FlattenSeparator": ".",
     "Format": "dotenv",
     "StringifiedValues": true,
-    "ResourceType": "SECRET",
-    "CreationType": "SINGLE"
+    "ResourceType": "SECRET"
    },
    "UpdateReplacePolicy": "Delete",
    "DeletionPolicy": "Delete"
@@ -355,8 +351,7 @@
     "FlattenSeparator": ".",
     "Format": "dotenv",
     "StringifiedValues": true,
-    "ResourceType": "SECRET",
-    "CreationType": "SINGLE"
+    "ResourceType": "SECRET"
    },
    "UpdateReplacePolicy": "Delete",
    "DeletionPolicy": "Delete"
@@ -390,8 +385,7 @@
     "FlattenSeparator": ".",
     "Format": "json",
     "StringifiedValues": true,
-    "ResourceType": "SECRET",
-    "CreationType": "SINGLE"
+    "ResourceType": "SECRET"
    },
    "UpdateReplacePolicy": "Delete",
    "DeletionPolicy": "Delete"
@@ -425,8 +419,7 @@
     "FlattenSeparator": ".",
     "Format": "json",
     "StringifiedValues": true,
-    "ResourceType": "SECRET",
-    "CreationType": "SINGLE"
+    "ResourceType": "SECRET"
    },
    "UpdateReplacePolicy": "Delete",
    "DeletionPolicy": "Delete"
@@ -460,8 +453,7 @@
     "FlattenSeparator": ".",
     "Format": "yaml",
     "StringifiedValues": true,
-    "ResourceType": "SECRET",
-    "CreationType": "SINGLE"
+    "ResourceType": "SECRET"
    },
    "UpdateReplacePolicy": "Delete",
    "DeletionPolicy": "Delete"
@@ -495,8 +487,7 @@
     "FlattenSeparator": ".",
     "Format": "yaml",
     "StringifiedValues": true,
-    "ResourceType": "SECRET",
-    "CreationType": "SINGLE"
+    "ResourceType": "SECRET"
    },
    "UpdateReplacePolicy": "Delete",
    "DeletionPolicy": "Delete"
@@ -530,8 +521,7 @@
     "FlattenSeparator": ".",
     "Format": "yaml",
     "StringifiedValues": true,
-    "ResourceType": "SECRET",
-    "CreationType": "SINGLE"
+    "ResourceType": "SECRET"
    },
    "UpdateReplacePolicy": "Delete",
    "DeletionPolicy": "Delete"
@@ -565,8 +555,7 @@
     "FlattenSeparator": ".",
     "Format": "yaml",
     "StringifiedValues": true,
-    "ResourceType": "SECRET",
-    "CreationType": "SINGLE"
+    "ResourceType": "SECRET"
    },
    "UpdateReplacePolicy": "Delete",
    "DeletionPolicy": "Delete"

--- a/test/secret-inline.integ.snapshot/SecretIntegrationInline.template.json
+++ b/test/secret-inline.integ.snapshot/SecretIntegrationInline.template.json
@@ -198,7 +198,7 @@
      "S3Bucket": {
       "Fn::Sub": "cdk-hnb659fds-assets-${AWS::AccountId}-${AWS::Region}"
      },
-     "S3Key": "bb705793a0bd8690a29d62191cd5ca3e4e0ebf81a9bf0a2677e8a30f841cafa2.zip"
+     "S3Key": "2c430c0ffff3fd5da4b853228c31f277ebb757a3e9a3f5e11321eb0cd8c91887.zip"
     },
     "Environment": {
      "Variables": {

--- a/test/secret-inline.integ.snapshot/SecretIntegrationInline.template.json
+++ b/test/secret-inline.integ.snapshot/SecretIntegrationInline.template.json
@@ -198,7 +198,7 @@
      "S3Bucket": {
       "Fn::Sub": "cdk-hnb659fds-assets-${AWS::AccountId}-${AWS::Region}"
      },
-     "S3Key": "3b70dd74522545fd1512f35f09eee7be6b317571aa28afc14540a494b3e5c4ee.zip"
+     "S3Key": "bb705793a0bd8690a29d62191cd5ca3e4e0ebf81a9bf0a2677e8a30f841cafa2.zip"
     },
     "Environment": {
      "Variables": {

--- a/test/secret-manual.integ.snapshot/SecretIntegrationAsset.assets.json
+++ b/test/secret-manual.integ.snapshot/SecretIntegrationAsset.assets.json
@@ -1,20 +1,20 @@
 {
   "version": "36.0.0",
   "files": {
-    "3b70dd74522545fd1512f35f09eee7be6b317571aa28afc14540a494b3e5c4ee": {
+    "bb705793a0bd8690a29d62191cd5ca3e4e0ebf81a9bf0a2677e8a30f841cafa2": {
       "source": {
-        "path": "asset.3b70dd74522545fd1512f35f09eee7be6b317571aa28afc14540a494b3e5c4ee.zip",
+        "path": "asset.bb705793a0bd8690a29d62191cd5ca3e4e0ebf81a9bf0a2677e8a30f841cafa2.zip",
         "packaging": "file"
       },
       "destinations": {
         "current_account-current_region": {
           "bucketName": "cdk-hnb659fds-assets-${AWS::AccountId}-${AWS::Region}",
-          "objectKey": "3b70dd74522545fd1512f35f09eee7be6b317571aa28afc14540a494b3e5c4ee.zip",
+          "objectKey": "bb705793a0bd8690a29d62191cd5ca3e4e0ebf81a9bf0a2677e8a30f841cafa2.zip",
           "assumeRoleArn": "arn:${AWS::Partition}:iam::${AWS::AccountId}:role/cdk-hnb659fds-file-publishing-role-${AWS::AccountId}-${AWS::Region}"
         }
       }
     },
-    "c0217209da80af0f706b2861e7a73ee40c2169f5d2276de65475e2256d077401": {
+    "97fd60ebfa8440e4000cef3de6f7fe157f40d4d8f917942aa0ee7e4f229b489d": {
       "source": {
         "path": "SecretIntegrationAsset.template.json",
         "packaging": "file"
@@ -22,7 +22,7 @@
       "destinations": {
         "current_account-current_region": {
           "bucketName": "cdk-hnb659fds-assets-${AWS::AccountId}-${AWS::Region}",
-          "objectKey": "c0217209da80af0f706b2861e7a73ee40c2169f5d2276de65475e2256d077401.json",
+          "objectKey": "97fd60ebfa8440e4000cef3de6f7fe157f40d4d8f917942aa0ee7e4f229b489d.json",
           "assumeRoleArn": "arn:${AWS::Partition}:iam::${AWS::AccountId}:role/cdk-hnb659fds-file-publishing-role-${AWS::AccountId}-${AWS::Region}"
         }
       }

--- a/test/secret-manual.integ.snapshot/SecretIntegrationAsset.assets.json
+++ b/test/secret-manual.integ.snapshot/SecretIntegrationAsset.assets.json
@@ -1,20 +1,20 @@
 {
   "version": "36.0.0",
   "files": {
-    "b84f4ae044484433485a09ba2d15bdd1cd134698fecd0af024e8a36b2c001d92": {
+    "3b70dd74522545fd1512f35f09eee7be6b317571aa28afc14540a494b3e5c4ee": {
       "source": {
-        "path": "asset.b84f4ae044484433485a09ba2d15bdd1cd134698fecd0af024e8a36b2c001d92.zip",
+        "path": "asset.3b70dd74522545fd1512f35f09eee7be6b317571aa28afc14540a494b3e5c4ee.zip",
         "packaging": "file"
       },
       "destinations": {
         "current_account-current_region": {
           "bucketName": "cdk-hnb659fds-assets-${AWS::AccountId}-${AWS::Region}",
-          "objectKey": "b84f4ae044484433485a09ba2d15bdd1cd134698fecd0af024e8a36b2c001d92.zip",
+          "objectKey": "3b70dd74522545fd1512f35f09eee7be6b317571aa28afc14540a494b3e5c4ee.zip",
           "assumeRoleArn": "arn:${AWS::Partition}:iam::${AWS::AccountId}:role/cdk-hnb659fds-file-publishing-role-${AWS::AccountId}-${AWS::Region}"
         }
       }
     },
-    "d4e0b1978d4b4a8bd4a3460f5250588a128ba18a716657ee533bbc19a93d6ce7": {
+    "c0217209da80af0f706b2861e7a73ee40c2169f5d2276de65475e2256d077401": {
       "source": {
         "path": "SecretIntegrationAsset.template.json",
         "packaging": "file"
@@ -22,7 +22,7 @@
       "destinations": {
         "current_account-current_region": {
           "bucketName": "cdk-hnb659fds-assets-${AWS::AccountId}-${AWS::Region}",
-          "objectKey": "d4e0b1978d4b4a8bd4a3460f5250588a128ba18a716657ee533bbc19a93d6ce7.json",
+          "objectKey": "c0217209da80af0f706b2861e7a73ee40c2169f5d2276de65475e2256d077401.json",
           "assumeRoleArn": "arn:${AWS::Partition}:iam::${AWS::AccountId}:role/cdk-hnb659fds-file-publishing-role-${AWS::AccountId}-${AWS::Region}"
         }
       }

--- a/test/secret-manual.integ.snapshot/SecretIntegrationAsset.assets.json
+++ b/test/secret-manual.integ.snapshot/SecretIntegrationAsset.assets.json
@@ -1,20 +1,20 @@
 {
   "version": "36.0.0",
   "files": {
-    "bb705793a0bd8690a29d62191cd5ca3e4e0ebf81a9bf0a2677e8a30f841cafa2": {
+    "2c430c0ffff3fd5da4b853228c31f277ebb757a3e9a3f5e11321eb0cd8c91887": {
       "source": {
-        "path": "asset.bb705793a0bd8690a29d62191cd5ca3e4e0ebf81a9bf0a2677e8a30f841cafa2.zip",
+        "path": "asset.2c430c0ffff3fd5da4b853228c31f277ebb757a3e9a3f5e11321eb0cd8c91887.zip",
         "packaging": "file"
       },
       "destinations": {
         "current_account-current_region": {
           "bucketName": "cdk-hnb659fds-assets-${AWS::AccountId}-${AWS::Region}",
-          "objectKey": "bb705793a0bd8690a29d62191cd5ca3e4e0ebf81a9bf0a2677e8a30f841cafa2.zip",
+          "objectKey": "2c430c0ffff3fd5da4b853228c31f277ebb757a3e9a3f5e11321eb0cd8c91887.zip",
           "assumeRoleArn": "arn:${AWS::Partition}:iam::${AWS::AccountId}:role/cdk-hnb659fds-file-publishing-role-${AWS::AccountId}-${AWS::Region}"
         }
       }
     },
-    "97fd60ebfa8440e4000cef3de6f7fe157f40d4d8f917942aa0ee7e4f229b489d": {
+    "d991538757fc85d0c7183933598d0517ea224a4d379c5cc40388ef064f255f29": {
       "source": {
         "path": "SecretIntegrationAsset.template.json",
         "packaging": "file"
@@ -22,7 +22,7 @@
       "destinations": {
         "current_account-current_region": {
           "bucketName": "cdk-hnb659fds-assets-${AWS::AccountId}-${AWS::Region}",
-          "objectKey": "97fd60ebfa8440e4000cef3de6f7fe157f40d4d8f917942aa0ee7e4f229b489d.json",
+          "objectKey": "d991538757fc85d0c7183933598d0517ea224a4d379c5cc40388ef064f255f29.json",
           "assumeRoleArn": "arn:${AWS::Partition}:iam::${AWS::AccountId}:role/cdk-hnb659fds-file-publishing-role-${AWS::AccountId}-${AWS::Region}"
         }
       }

--- a/test/secret-manual.integ.snapshot/SecretIntegrationAsset.template.json
+++ b/test/secret-manual.integ.snapshot/SecretIntegrationAsset.template.json
@@ -72,7 +72,7 @@
      "S3Bucket": {
       "Fn::Sub": "cdk-hnb659fds-assets-${AWS::AccountId}-${AWS::Region}"
      },
-     "S3Key": "3b70dd74522545fd1512f35f09eee7be6b317571aa28afc14540a494b3e5c4ee.zip"
+     "S3Key": "bb705793a0bd8690a29d62191cd5ca3e4e0ebf81a9bf0a2677e8a30f841cafa2.zip"
     },
     "Environment": {
      "Variables": {

--- a/test/secret-manual.integ.snapshot/SecretIntegrationAsset.template.json
+++ b/test/secret-manual.integ.snapshot/SecretIntegrationAsset.template.json
@@ -29,8 +29,7 @@
     "FlattenSeparator": ".",
     "Format": "json",
     "StringifiedValues": true,
-    "ResourceType": "SECRET",
-    "CreationType": "SINGLE"
+    "ResourceType": "SECRET"
    },
    "UpdateReplacePolicy": "Delete",
    "DeletionPolicy": "Delete"
@@ -73,7 +72,7 @@
      "S3Bucket": {
       "Fn::Sub": "cdk-hnb659fds-assets-${AWS::AccountId}-${AWS::Region}"
      },
-     "S3Key": "b84f4ae044484433485a09ba2d15bdd1cd134698fecd0af024e8a36b2c001d92.zip"
+     "S3Key": "3b70dd74522545fd1512f35f09eee7be6b317571aa28afc14540a494b3e5c4ee.zip"
     },
     "Environment": {
      "Variables": {
@@ -123,8 +122,7 @@
     "FlattenSeparator": ".",
     "Format": "json",
     "StringifiedValues": true,
-    "ResourceType": "SECRET",
-    "CreationType": "SINGLE"
+    "ResourceType": "SECRET"
    },
    "UpdateReplacePolicy": "Delete",
    "DeletionPolicy": "Delete"
@@ -158,8 +156,7 @@
     "FlattenSeparator": ".",
     "Format": "yaml",
     "StringifiedValues": true,
-    "ResourceType": "SECRET",
-    "CreationType": "SINGLE"
+    "ResourceType": "SECRET"
    },
    "UpdateReplacePolicy": "Delete",
    "DeletionPolicy": "Delete"
@@ -193,8 +190,7 @@
     "FlattenSeparator": ".",
     "Format": "json",
     "StringifiedValues": true,
-    "ResourceType": "SECRET",
-    "CreationType": "SINGLE"
+    "ResourceType": "SECRET"
    },
    "UpdateReplacePolicy": "Delete",
    "DeletionPolicy": "Delete"
@@ -228,8 +224,7 @@
     "FlattenSeparator": ".",
     "Format": "json",
     "StringifiedValues": true,
-    "ResourceType": "SECRET",
-    "CreationType": "SINGLE"
+    "ResourceType": "SECRET"
    },
    "UpdateReplacePolicy": "Delete",
    "DeletionPolicy": "Delete"
@@ -263,8 +258,7 @@
     "FlattenSeparator": ".",
     "Format": "yaml",
     "StringifiedValues": true,
-    "ResourceType": "SECRET",
-    "CreationType": "SINGLE"
+    "ResourceType": "SECRET"
    },
    "UpdateReplacePolicy": "Delete",
    "DeletionPolicy": "Delete"
@@ -298,8 +292,7 @@
     "FlattenSeparator": ".",
     "Format": "yaml",
     "StringifiedValues": true,
-    "ResourceType": "SECRET",
-    "CreationType": "SINGLE"
+    "ResourceType": "SECRET"
    },
    "UpdateReplacePolicy": "Delete",
    "DeletionPolicy": "Delete"
@@ -333,8 +326,7 @@
     "FlattenSeparator": ".",
     "Format": "yaml",
     "StringifiedValues": true,
-    "ResourceType": "SECRET",
-    "CreationType": "SINGLE"
+    "ResourceType": "SECRET"
    },
    "UpdateReplacePolicy": "Delete",
    "DeletionPolicy": "Delete"
@@ -368,8 +360,7 @@
     "FlattenSeparator": ".",
     "Format": "yaml",
     "StringifiedValues": true,
-    "ResourceType": "SECRET",
-    "CreationType": "SINGLE"
+    "ResourceType": "SECRET"
    },
    "UpdateReplacePolicy": "Delete",
    "DeletionPolicy": "Delete"

--- a/test/secret-manual.integ.snapshot/SecretIntegrationAsset.template.json
+++ b/test/secret-manual.integ.snapshot/SecretIntegrationAsset.template.json
@@ -72,7 +72,7 @@
      "S3Bucket": {
       "Fn::Sub": "cdk-hnb659fds-assets-${AWS::AccountId}-${AWS::Region}"
      },
-     "S3Key": "bb705793a0bd8690a29d62191cd5ca3e4e0ebf81a9bf0a2677e8a30f841cafa2.zip"
+     "S3Key": "2c430c0ffff3fd5da4b853228c31f277ebb757a3e9a3f5e11321eb0cd8c91887.zip"
     },
     "Environment": {
      "Variables": {

--- a/test/secret-multikms.integ.snapshot/SecretMultiKms.assets.json
+++ b/test/secret-multikms.integ.snapshot/SecretMultiKms.assets.json
@@ -1,15 +1,15 @@
 {
   "version": "36.0.0",
   "files": {
-    "b84f4ae044484433485a09ba2d15bdd1cd134698fecd0af024e8a36b2c001d92": {
+    "3b70dd74522545fd1512f35f09eee7be6b317571aa28afc14540a494b3e5c4ee": {
       "source": {
-        "path": "asset.b84f4ae044484433485a09ba2d15bdd1cd134698fecd0af024e8a36b2c001d92.zip",
+        "path": "asset.3b70dd74522545fd1512f35f09eee7be6b317571aa28afc14540a494b3e5c4ee.zip",
         "packaging": "file"
       },
       "destinations": {
         "current_account-current_region": {
           "bucketName": "cdk-hnb659fds-assets-${AWS::AccountId}-${AWS::Region}",
-          "objectKey": "b84f4ae044484433485a09ba2d15bdd1cd134698fecd0af024e8a36b2c001d92.zip",
+          "objectKey": "3b70dd74522545fd1512f35f09eee7be6b317571aa28afc14540a494b3e5c4ee.zip",
           "assumeRoleArn": "arn:${AWS::Partition}:iam::${AWS::AccountId}:role/cdk-hnb659fds-file-publishing-role-${AWS::AccountId}-${AWS::Region}"
         }
       }
@@ -27,7 +27,7 @@
         }
       }
     },
-    "b2891d8d1afc3baddc99715abe47f05ff84ad390166c5277a91fc50103fc4457": {
+    "66e5133c6541e8a6ba203faa3f313ab163bfc78f98fa4185c342a364934a303b": {
       "source": {
         "path": "SecretMultiKms.template.json",
         "packaging": "file"
@@ -35,7 +35,7 @@
       "destinations": {
         "current_account-current_region": {
           "bucketName": "cdk-hnb659fds-assets-${AWS::AccountId}-${AWS::Region}",
-          "objectKey": "b2891d8d1afc3baddc99715abe47f05ff84ad390166c5277a91fc50103fc4457.json",
+          "objectKey": "66e5133c6541e8a6ba203faa3f313ab163bfc78f98fa4185c342a364934a303b.json",
           "assumeRoleArn": "arn:${AWS::Partition}:iam::${AWS::AccountId}:role/cdk-hnb659fds-file-publishing-role-${AWS::AccountId}-${AWS::Region}"
         }
       }

--- a/test/secret-multikms.integ.snapshot/SecretMultiKms.assets.json
+++ b/test/secret-multikms.integ.snapshot/SecretMultiKms.assets.json
@@ -1,15 +1,15 @@
 {
   "version": "36.0.0",
   "files": {
-    "3b70dd74522545fd1512f35f09eee7be6b317571aa28afc14540a494b3e5c4ee": {
+    "bb705793a0bd8690a29d62191cd5ca3e4e0ebf81a9bf0a2677e8a30f841cafa2": {
       "source": {
-        "path": "asset.3b70dd74522545fd1512f35f09eee7be6b317571aa28afc14540a494b3e5c4ee.zip",
+        "path": "asset.bb705793a0bd8690a29d62191cd5ca3e4e0ebf81a9bf0a2677e8a30f841cafa2.zip",
         "packaging": "file"
       },
       "destinations": {
         "current_account-current_region": {
           "bucketName": "cdk-hnb659fds-assets-${AWS::AccountId}-${AWS::Region}",
-          "objectKey": "3b70dd74522545fd1512f35f09eee7be6b317571aa28afc14540a494b3e5c4ee.zip",
+          "objectKey": "bb705793a0bd8690a29d62191cd5ca3e4e0ebf81a9bf0a2677e8a30f841cafa2.zip",
           "assumeRoleArn": "arn:${AWS::Partition}:iam::${AWS::AccountId}:role/cdk-hnb659fds-file-publishing-role-${AWS::AccountId}-${AWS::Region}"
         }
       }
@@ -27,7 +27,7 @@
         }
       }
     },
-    "66e5133c6541e8a6ba203faa3f313ab163bfc78f98fa4185c342a364934a303b": {
+    "e30d5ef78da253f697f3bf0aaf72550fceb9a9eefae9469f6eb7008380f429cb": {
       "source": {
         "path": "SecretMultiKms.template.json",
         "packaging": "file"
@@ -35,7 +35,7 @@
       "destinations": {
         "current_account-current_region": {
           "bucketName": "cdk-hnb659fds-assets-${AWS::AccountId}-${AWS::Region}",
-          "objectKey": "66e5133c6541e8a6ba203faa3f313ab163bfc78f98fa4185c342a364934a303b.json",
+          "objectKey": "e30d5ef78da253f697f3bf0aaf72550fceb9a9eefae9469f6eb7008380f429cb.json",
           "assumeRoleArn": "arn:${AWS::Partition}:iam::${AWS::AccountId}:role/cdk-hnb659fds-file-publishing-role-${AWS::AccountId}-${AWS::Region}"
         }
       }

--- a/test/secret-multikms.integ.snapshot/SecretMultiKms.assets.json
+++ b/test/secret-multikms.integ.snapshot/SecretMultiKms.assets.json
@@ -1,15 +1,15 @@
 {
   "version": "36.0.0",
   "files": {
-    "bb705793a0bd8690a29d62191cd5ca3e4e0ebf81a9bf0a2677e8a30f841cafa2": {
+    "2c430c0ffff3fd5da4b853228c31f277ebb757a3e9a3f5e11321eb0cd8c91887": {
       "source": {
-        "path": "asset.bb705793a0bd8690a29d62191cd5ca3e4e0ebf81a9bf0a2677e8a30f841cafa2.zip",
+        "path": "asset.2c430c0ffff3fd5da4b853228c31f277ebb757a3e9a3f5e11321eb0cd8c91887.zip",
         "packaging": "file"
       },
       "destinations": {
         "current_account-current_region": {
           "bucketName": "cdk-hnb659fds-assets-${AWS::AccountId}-${AWS::Region}",
-          "objectKey": "bb705793a0bd8690a29d62191cd5ca3e4e0ebf81a9bf0a2677e8a30f841cafa2.zip",
+          "objectKey": "2c430c0ffff3fd5da4b853228c31f277ebb757a3e9a3f5e11321eb0cd8c91887.zip",
           "assumeRoleArn": "arn:${AWS::Partition}:iam::${AWS::AccountId}:role/cdk-hnb659fds-file-publishing-role-${AWS::AccountId}-${AWS::Region}"
         }
       }
@@ -27,7 +27,7 @@
         }
       }
     },
-    "e30d5ef78da253f697f3bf0aaf72550fceb9a9eefae9469f6eb7008380f429cb": {
+    "6bf23bfa8222ed50eef10cf00cfb221343b0f056159410f55f8a28dc7c92b9b6": {
       "source": {
         "path": "SecretMultiKms.template.json",
         "packaging": "file"
@@ -35,7 +35,7 @@
       "destinations": {
         "current_account-current_region": {
           "bucketName": "cdk-hnb659fds-assets-${AWS::AccountId}-${AWS::Region}",
-          "objectKey": "e30d5ef78da253f697f3bf0aaf72550fceb9a9eefae9469f6eb7008380f429cb.json",
+          "objectKey": "6bf23bfa8222ed50eef10cf00cfb221343b0f056159410f55f8a28dc7c92b9b6.json",
           "assumeRoleArn": "arn:${AWS::Partition}:iam::${AWS::AccountId}:role/cdk-hnb659fds-file-publishing-role-${AWS::AccountId}-${AWS::Region}"
         }
       }

--- a/test/secret-multikms.integ.snapshot/SecretMultiKms.template.json
+++ b/test/secret-multikms.integ.snapshot/SecretMultiKms.template.json
@@ -336,7 +336,7 @@
      "S3Bucket": {
       "Fn::Sub": "cdk-hnb659fds-assets-${AWS::AccountId}-${AWS::Region}"
      },
-     "S3Key": "3b70dd74522545fd1512f35f09eee7be6b317571aa28afc14540a494b3e5c4ee.zip"
+     "S3Key": "bb705793a0bd8690a29d62191cd5ca3e4e0ebf81a9bf0a2677e8a30f841cafa2.zip"
     },
     "Environment": {
      "Variables": {

--- a/test/secret-multikms.integ.snapshot/SecretMultiKms.template.json
+++ b/test/secret-multikms.integ.snapshot/SecretMultiKms.template.json
@@ -191,8 +191,7 @@
     "FlattenSeparator": ".",
     "Format": "json",
     "StringifiedValues": true,
-    "ResourceType": "SECRET",
-    "CreationType": "SINGLE"
+    "ResourceType": "SECRET"
    },
    "UpdateReplacePolicy": "Delete",
    "DeletionPolicy": "Delete"
@@ -233,31 +232,6 @@
    "Properties": {
     "PolicyDocument": {
      "Statement": [
-      {
-       "Action": [
-        "secretsmanager:PutSecretValue",
-        "secretsmanager:UpdateSecret"
-       ],
-       "Effect": "Allow",
-       "Resource": {
-        "Ref": "SopsSecretOwnKmsMey0B320436"
-       }
-      },
-      {
-       "Action": [
-        "kms:Decrypt",
-        "kms:Encrypt",
-        "kms:ReEncrypt*",
-        "kms:GenerateDataKey*"
-       ],
-       "Effect": "Allow",
-       "Resource": {
-        "Fn::GetAtt": [
-         "CustomKey1E6D0D07",
-         "Arn"
-        ]
-       }
-      },
       {
        "Action": [
         "s3:GetObject*",
@@ -301,12 +275,27 @@
       },
       {
        "Action": [
+        "kms:Decrypt",
+        "kms:Encrypt",
+        "kms:ReEncrypt*",
+        "kms:GenerateDataKey*"
+       ],
+       "Effect": "Allow",
+       "Resource": {
+        "Fn::GetAtt": [
+         "CustomKey1E6D0D07",
+         "Arn"
+        ]
+       }
+      },
+      {
+       "Action": [
         "secretsmanager:PutSecretValue",
         "secretsmanager:UpdateSecret"
        ],
        "Effect": "Allow",
        "Resource": {
-        "Ref": "SopsSecretForeignKmsMey8C3BA0B7"
+        "Ref": "SopsSecretOwnKmsMey0B320436"
        }
       },
       {
@@ -318,6 +307,16 @@
        ],
        "Effect": "Allow",
        "Resource": "arn:aws:kms:us-east-1:123456789012:key/12345678-1234-1234-1234-123456789012"
+      },
+      {
+       "Action": [
+        "secretsmanager:PutSecretValue",
+        "secretsmanager:UpdateSecret"
+       ],
+       "Effect": "Allow",
+       "Resource": {
+        "Ref": "SopsSecretForeignKmsMey8C3BA0B7"
+       }
       }
      ],
      "Version": "2012-10-17"
@@ -337,7 +336,7 @@
      "S3Bucket": {
       "Fn::Sub": "cdk-hnb659fds-assets-${AWS::AccountId}-${AWS::Region}"
      },
-     "S3Key": "b84f4ae044484433485a09ba2d15bdd1cd134698fecd0af024e8a36b2c001d92.zip"
+     "S3Key": "3b70dd74522545fd1512f35f09eee7be6b317571aa28afc14540a494b3e5c4ee.zip"
     },
     "Environment": {
      "Variables": {
@@ -391,8 +390,7 @@
     "FlattenSeparator": ".",
     "Format": "json",
     "StringifiedValues": true,
-    "ResourceType": "SECRET",
-    "CreationType": "SINGLE"
+    "ResourceType": "SECRET"
    },
    "UpdateReplacePolicy": "Delete",
    "DeletionPolicy": "Delete"

--- a/test/secret-multikms.integ.snapshot/SecretMultiKms.template.json
+++ b/test/secret-multikms.integ.snapshot/SecretMultiKms.template.json
@@ -336,7 +336,7 @@
      "S3Bucket": {
       "Fn::Sub": "cdk-hnb659fds-assets-${AWS::AccountId}-${AWS::Region}"
      },
-     "S3Key": "bb705793a0bd8690a29d62191cd5ca3e4e0ebf81a9bf0a2677e8a30f841cafa2.zip"
+     "S3Key": "2c430c0ffff3fd5da4b853228c31f277ebb757a3e9a3f5e11321eb0cd8c91887.zip"
     },
     "Environment": {
      "Variables": {

--- a/test/secret.test.ts
+++ b/test/secret.test.ts
@@ -506,7 +506,7 @@ test('Allowed options for SopsSync', () => {
         sopsS3Key: 'test',
       }),
   ).toThrowError(
-    'You have to specify both sopsS3Bucket and sopsS3Key or neither!',
+    'You can either specify sopsFilePath or sopsS3Bucket and sopsS3Key!',
   );
   expect(
     () =>
@@ -514,7 +514,7 @@ test('Allowed options for SopsSync', () => {
         sopsS3Bucket: 'test',
       }),
   ).toThrowError(
-    'You have to specify both sopsS3Bucket and sopsS3Key or neither!',
+    'You can either specify sopsFilePath or sopsS3Bucket and sopsS3Key!',
   );
   expect(
     () =>


### PR DESCRIPTION
- remove CreationType (Single, Multi)
- replace with ResourceType (PARAMETER_MULTI) and move it to properties fixes: #1076
- add property 'autoGenerateIamPermissions' fixes: #1087
- add property 'role' for SopsSyncProvider fixes: #1087
- move resourceType from syncOptions to syncProperties, as it shouldn't be set by users
- move permissionhandling to own functions, to reduce cyclomatic compexity

Fixes #1076, #1087