### PR TITLE
feat: Support plaintext secrets

### DIFF
--- a/API.md
+++ b/API.md
@@ -1722,6 +1722,7 @@ const multiStringParameterProps: MultiStringParameterProps = { ... }
 | <code><a href="#cdk-sops-secrets.MultiStringParameterProps.property.flatten">flatten</a></code> | <code>boolean</code> | Should the structure be flattened? |
 | <code><a href="#cdk-sops-secrets.MultiStringParameterProps.property.flattenSeparator">flattenSeparator</a></code> | <code>string</code> | If the structure should be flattened use the provided separator between keys. |
 | <code><a href="#cdk-sops-secrets.MultiStringParameterProps.property.parameterKeyPrefix">parameterKeyPrefix</a></code> | <code>string</code> | Add this prefix to parameter names. |
+| <code><a href="#cdk-sops-secrets.MultiStringParameterProps.property.plaintext">plaintext</a></code> | <code>boolean</code> | Remove any JSON/Yaml object structure and store this secret as a plaintext secret. |
 | <code><a href="#cdk-sops-secrets.MultiStringParameterProps.property.sopsAgeKey">sopsAgeKey</a></code> | <code>aws-cdk-lib.SecretValue</code> | The age key that should be used for encryption. |
 | <code><a href="#cdk-sops-secrets.MultiStringParameterProps.property.sopsFileFormat">sopsFileFormat</a></code> | <code>string</code> | The format of the sops file. |
 | <code><a href="#cdk-sops-secrets.MultiStringParameterProps.property.sopsFilePath">sopsFilePath</a></code> | <code>string</code> | The filepath to the sops file. |
@@ -1812,6 +1813,22 @@ public readonly parameterKeyPrefix: string;
 - *Type:* string
 
 Add this prefix to parameter names.
+
+---
+
+##### `plaintext`<sup>Optional</sup> <a name="plaintext" id="cdk-sops-secrets.MultiStringParameterProps.property.plaintext"></a>
+
+```typescript
+public readonly plaintext: boolean;
+```
+
+- *Type:* boolean
+
+Remove any JSON/Yaml object structure and store this secret as a plaintext secret.
+
+SOPS files must contain a JSON/Yaml object on the toplevel, they cannot store only a single string.
+As a workaround, you can enable this flag and use the following format in the SOPS file:
+`data: "secret value"`. Only the secret value will be synced to AWS Secrets Manager.
 
 ---
 
@@ -2114,6 +2131,7 @@ const sopsSecretProps: SopsSecretProps = { ... }
 | <code><a href="#cdk-sops-secrets.SopsSecretProps.property.flatten">flatten</a></code> | <code>boolean</code> | Should the structure be flattened? |
 | <code><a href="#cdk-sops-secrets.SopsSecretProps.property.flattenSeparator">flattenSeparator</a></code> | <code>string</code> | If the structure should be flattened use the provided separator between keys. |
 | <code><a href="#cdk-sops-secrets.SopsSecretProps.property.parameterKeyPrefix">parameterKeyPrefix</a></code> | <code>string</code> | Add this prefix to parameter names. |
+| <code><a href="#cdk-sops-secrets.SopsSecretProps.property.plaintext">plaintext</a></code> | <code>boolean</code> | Remove any JSON/Yaml object structure and store this secret as a plaintext secret. |
 | <code><a href="#cdk-sops-secrets.SopsSecretProps.property.sopsAgeKey">sopsAgeKey</a></code> | <code>aws-cdk-lib.SecretValue</code> | The age key that should be used for encryption. |
 | <code><a href="#cdk-sops-secrets.SopsSecretProps.property.sopsFileFormat">sopsFileFormat</a></code> | <code>string</code> | The format of the sops file. |
 | <code><a href="#cdk-sops-secrets.SopsSecretProps.property.sopsFilePath">sopsFilePath</a></code> | <code>string</code> | The filepath to the sops file. |
@@ -2369,6 +2387,22 @@ Add this prefix to parameter names.
 
 ---
 
+##### `plaintext`<sup>Optional</sup> <a name="plaintext" id="cdk-sops-secrets.SopsSecretProps.property.plaintext"></a>
+
+```typescript
+public readonly plaintext: boolean;
+```
+
+- *Type:* boolean
+
+Remove any JSON/Yaml object structure and store this secret as a plaintext secret.
+
+SOPS files must contain a JSON/Yaml object on the toplevel, they cannot store only a single string.
+As a workaround, you can enable this flag and use the following format in the SOPS file:
+`data: "secret value"`. Only the secret value will be synced to AWS Secrets Manager.
+
+---
+
 ##### `sopsAgeKey`<sup>Optional</sup> <a name="sopsAgeKey" id="cdk-sops-secrets.SopsSecretProps.property.sopsAgeKey"></a>
 
 ```typescript
@@ -2511,6 +2545,7 @@ const sopsStringParameterProps: SopsStringParameterProps = { ... }
 | <code><a href="#cdk-sops-secrets.SopsStringParameterProps.property.flatten">flatten</a></code> | <code>boolean</code> | Should the structure be flattened? |
 | <code><a href="#cdk-sops-secrets.SopsStringParameterProps.property.flattenSeparator">flattenSeparator</a></code> | <code>string</code> | If the structure should be flattened use the provided separator between keys. |
 | <code><a href="#cdk-sops-secrets.SopsStringParameterProps.property.parameterKeyPrefix">parameterKeyPrefix</a></code> | <code>string</code> | Add this prefix to parameter names. |
+| <code><a href="#cdk-sops-secrets.SopsStringParameterProps.property.plaintext">plaintext</a></code> | <code>boolean</code> | Remove any JSON/Yaml object structure and store this secret as a plaintext secret. |
 | <code><a href="#cdk-sops-secrets.SopsStringParameterProps.property.sopsAgeKey">sopsAgeKey</a></code> | <code>aws-cdk-lib.SecretValue</code> | The age key that should be used for encryption. |
 | <code><a href="#cdk-sops-secrets.SopsStringParameterProps.property.sopsFileFormat">sopsFileFormat</a></code> | <code>string</code> | The format of the sops file. |
 | <code><a href="#cdk-sops-secrets.SopsStringParameterProps.property.sopsFilePath">sopsFilePath</a></code> | <code>string</code> | The filepath to the sops file. |
@@ -2599,6 +2634,22 @@ public readonly parameterKeyPrefix: string;
 - *Type:* string
 
 Add this prefix to parameter names.
+
+---
+
+##### `plaintext`<sup>Optional</sup> <a name="plaintext" id="cdk-sops-secrets.SopsStringParameterProps.property.plaintext"></a>
+
+```typescript
+public readonly plaintext: boolean;
+```
+
+- *Type:* boolean
+
+Remove any JSON/Yaml object structure and store this secret as a plaintext secret.
+
+SOPS files must contain a JSON/Yaml object on the toplevel, they cannot store only a single string.
+As a workaround, you can enable this flag and use the following format in the SOPS file:
+`data: "secret value"`. Only the secret value will be synced to AWS Secrets Manager.
 
 ---
 
@@ -2872,6 +2923,7 @@ const sopsSyncOptions: SopsSyncOptions = { ... }
 | <code><a href="#cdk-sops-secrets.SopsSyncOptions.property.flatten">flatten</a></code> | <code>boolean</code> | Should the structure be flattened? |
 | <code><a href="#cdk-sops-secrets.SopsSyncOptions.property.flattenSeparator">flattenSeparator</a></code> | <code>string</code> | If the structure should be flattened use the provided separator between keys. |
 | <code><a href="#cdk-sops-secrets.SopsSyncOptions.property.parameterKeyPrefix">parameterKeyPrefix</a></code> | <code>string</code> | Add this prefix to parameter names. |
+| <code><a href="#cdk-sops-secrets.SopsSyncOptions.property.plaintext">plaintext</a></code> | <code>boolean</code> | Remove any JSON/Yaml object structure and store this secret as a plaintext secret. |
 | <code><a href="#cdk-sops-secrets.SopsSyncOptions.property.sopsAgeKey">sopsAgeKey</a></code> | <code>aws-cdk-lib.SecretValue</code> | The age key that should be used for encryption. |
 | <code><a href="#cdk-sops-secrets.SopsSyncOptions.property.sopsFileFormat">sopsFileFormat</a></code> | <code>string</code> | The format of the sops file. |
 | <code><a href="#cdk-sops-secrets.SopsSyncOptions.property.sopsFilePath">sopsFilePath</a></code> | <code>string</code> | The filepath to the sops file. |
@@ -2951,6 +3003,22 @@ public readonly parameterKeyPrefix: string;
 - *Type:* string
 
 Add this prefix to parameter names.
+
+---
+
+##### `plaintext`<sup>Optional</sup> <a name="plaintext" id="cdk-sops-secrets.SopsSyncOptions.property.plaintext"></a>
+
+```typescript
+public readonly plaintext: boolean;
+```
+
+- *Type:* boolean
+
+Remove any JSON/Yaml object structure and store this secret as a plaintext secret.
+
+SOPS files must contain a JSON/Yaml object on the toplevel, they cannot store only a single string.
+As a workaround, you can enable this flag and use the following format in the SOPS file:
+`data: "secret value"`. Only the secret value will be synced to AWS Secrets Manager.
 
 ---
 
@@ -3096,6 +3164,7 @@ const sopsSyncProps: SopsSyncProps = { ... }
 | <code><a href="#cdk-sops-secrets.SopsSyncProps.property.flatten">flatten</a></code> | <code>boolean</code> | Should the structure be flattened? |
 | <code><a href="#cdk-sops-secrets.SopsSyncProps.property.flattenSeparator">flattenSeparator</a></code> | <code>string</code> | If the structure should be flattened use the provided separator between keys. |
 | <code><a href="#cdk-sops-secrets.SopsSyncProps.property.parameterKeyPrefix">parameterKeyPrefix</a></code> | <code>string</code> | Add this prefix to parameter names. |
+| <code><a href="#cdk-sops-secrets.SopsSyncProps.property.plaintext">plaintext</a></code> | <code>boolean</code> | Remove any JSON/Yaml object structure and store this secret as a plaintext secret. |
 | <code><a href="#cdk-sops-secrets.SopsSyncProps.property.sopsAgeKey">sopsAgeKey</a></code> | <code>aws-cdk-lib.SecretValue</code> | The age key that should be used for encryption. |
 | <code><a href="#cdk-sops-secrets.SopsSyncProps.property.sopsFileFormat">sopsFileFormat</a></code> | <code>string</code> | The format of the sops file. |
 | <code><a href="#cdk-sops-secrets.SopsSyncProps.property.sopsFilePath">sopsFilePath</a></code> | <code>string</code> | The filepath to the sops file. |
@@ -3179,6 +3248,22 @@ public readonly parameterKeyPrefix: string;
 - *Type:* string
 
 Add this prefix to parameter names.
+
+---
+
+##### `plaintext`<sup>Optional</sup> <a name="plaintext" id="cdk-sops-secrets.SopsSyncProps.property.plaintext"></a>
+
+```typescript
+public readonly plaintext: boolean;
+```
+
+- *Type:* boolean
+
+Remove any JSON/Yaml object structure and store this secret as a plaintext secret.
+
+SOPS files must contain a JSON/Yaml object on the toplevel, they cannot store only a single string.
+As a workaround, you can enable this flag and use the following format in the SOPS file:
+`data: "secret value"`. Only the secret value will be synced to AWS Secrets Manager.
 
 ---
 

--- a/src/SopsSync.ts
+++ b/src/SopsSync.ts
@@ -132,6 +132,14 @@ export interface SopsSyncOptions {
   readonly stringifyValues?: boolean;
 
   /**
+   * Remove any JSON/Yaml object structure and store this secret as a plaintext secret.
+   * SOPS files must contain a JSON/Yaml object on the toplevel, they cannot store only a single string.
+   * As a workaround, you can enable this flag and use the following format in the SOPS file:
+   * `data: "secret value"`. Only the secret value will be synced to AWS Secrets Manager.
+   */
+  readonly plaintext?: boolean;
+
+  /**
    * Should this construct automatically create IAM permissions?
    *
    * @default true
@@ -397,6 +405,7 @@ export class SopsSync extends Construct {
         ConvertToJSON: this.converToJSON,
         Flatten: this.flatten,
         FlattenSeparator: props.flattenSeparator ?? '.',
+        Plaintext: props.plaintext ?? false,
         ParameterKeyPrefix: props.parameterKeyPrefix,
         Format: sopsFileFormat,
         StringifiedValues: this.stringifiedValues,

--- a/test/secret-asset.integ.snapshot/SecretIntegrationAsset.assets.json
+++ b/test/secret-asset.integ.snapshot/SecretIntegrationAsset.assets.json
@@ -1,15 +1,15 @@
 {
   "version": "36.0.0",
   "files": {
-    "fbfa20a153a2fa8b2dd2685813107cbc28e1064a5ba511cdb6114b37e06eaaf7": {
+    "878ec41c762acb5343be65233f78e8443f1be88bb9d4dd2b46f85557146b0c59": {
       "source": {
-        "path": "asset.fbfa20a153a2fa8b2dd2685813107cbc28e1064a5ba511cdb6114b37e06eaaf7.zip",
+        "path": "asset.878ec41c762acb5343be65233f78e8443f1be88bb9d4dd2b46f85557146b0c59.zip",
         "packaging": "file"
       },
       "destinations": {
         "current_account-current_region": {
           "bucketName": "cdk-hnb659fds-assets-${AWS::AccountId}-${AWS::Region}",
-          "objectKey": "fbfa20a153a2fa8b2dd2685813107cbc28e1064a5ba511cdb6114b37e06eaaf7.zip",
+          "objectKey": "878ec41c762acb5343be65233f78e8443f1be88bb9d4dd2b46f85557146b0c59.zip",
           "assumeRoleArn": "arn:${AWS::Partition}:iam::${AWS::AccountId}:role/cdk-hnb659fds-file-publishing-role-${AWS::AccountId}-${AWS::Region}"
         }
       }
@@ -79,7 +79,7 @@
         }
       }
     },
-    "8af4c6d99b556a13f42260d42f6747b9c030c010ea8a79c58c8eed3d5011f5da": {
+    "2d3c5f01c96116ed4db89d97deab9a06330c97c63d355d9804b1a7c4af6eba25": {
       "source": {
         "path": "SecretIntegrationAsset.template.json",
         "packaging": "file"
@@ -87,7 +87,7 @@
       "destinations": {
         "current_account-current_region": {
           "bucketName": "cdk-hnb659fds-assets-${AWS::AccountId}-${AWS::Region}",
-          "objectKey": "8af4c6d99b556a13f42260d42f6747b9c030c010ea8a79c58c8eed3d5011f5da.json",
+          "objectKey": "2d3c5f01c96116ed4db89d97deab9a06330c97c63d355d9804b1a7c4af6eba25.json",
           "assumeRoleArn": "arn:${AWS::Partition}:iam::${AWS::AccountId}:role/cdk-hnb659fds-file-publishing-role-${AWS::AccountId}-${AWS::Region}"
         }
       }

--- a/test/secret-asset.integ.snapshot/SecretIntegrationAsset.template.json
+++ b/test/secret-asset.integ.snapshot/SecretIntegrationAsset.template.json
@@ -29,6 +29,7 @@
     "ConvertToJSON": true,
     "Flatten": true,
     "FlattenSeparator": ".",
+    "Plaintext": false,
     "Format": "json",
     "StringifiedValues": true,
     "ResourceType": "SECRET"
@@ -231,7 +232,7 @@
      "S3Bucket": {
       "Fn::Sub": "cdk-hnb659fds-assets-${AWS::AccountId}-${AWS::Region}"
      },
-     "S3Key": "fbfa20a153a2fa8b2dd2685813107cbc28e1064a5ba511cdb6114b37e06eaaf7.zip"
+     "S3Key": "878ec41c762acb5343be65233f78e8443f1be88bb9d4dd2b46f85557146b0c59.zip"
     },
     "Environment": {
      "Variables": {
@@ -282,6 +283,7 @@
     "ConvertToJSON": false,
     "Flatten": true,
     "FlattenSeparator": ".",
+    "Plaintext": false,
     "Format": "yaml",
     "StringifiedValues": true,
     "ResourceType": "SECRET"
@@ -318,6 +320,7 @@
     "ConvertToJSON": true,
     "Flatten": true,
     "FlattenSeparator": ".",
+    "Plaintext": false,
     "Format": "yaml",
     "StringifiedValues": true,
     "ResourceType": "SECRET"
@@ -354,6 +357,7 @@
     "ConvertToJSON": true,
     "Flatten": false,
     "FlattenSeparator": ".",
+    "Plaintext": false,
     "Format": "json",
     "StringifiedValues": true,
     "ResourceType": "SECRET"
@@ -390,6 +394,7 @@
     "ConvertToJSON": true,
     "Flatten": true,
     "FlattenSeparator": ".",
+    "Plaintext": false,
     "Format": "json",
     "StringifiedValues": true,
     "ResourceType": "SECRET"
@@ -426,6 +431,7 @@
     "ConvertToJSON": false,
     "Flatten": false,
     "FlattenSeparator": ".",
+    "Plaintext": false,
     "Format": "yaml",
     "StringifiedValues": true,
     "ResourceType": "SECRET"
@@ -462,6 +468,7 @@
     "ConvertToJSON": false,
     "Flatten": true,
     "FlattenSeparator": ".",
+    "Plaintext": false,
     "Format": "yaml",
     "StringifiedValues": true,
     "ResourceType": "SECRET"
@@ -498,6 +505,7 @@
     "ConvertToJSON": true,
     "Flatten": false,
     "FlattenSeparator": ".",
+    "Plaintext": false,
     "Format": "yaml",
     "StringifiedValues": true,
     "ResourceType": "SECRET"
@@ -534,6 +542,7 @@
     "ConvertToJSON": true,
     "Flatten": true,
     "FlattenSeparator": ".",
+    "Plaintext": false,
     "Format": "yaml",
     "StringifiedValues": true,
     "ResourceType": "SECRET"
@@ -570,6 +579,7 @@
     "ConvertToJSON": true,
     "Flatten": true,
     "FlattenSeparator": ".",
+    "Plaintext": false,
     "Format": "binary",
     "StringifiedValues": true,
     "ResourceType": "SECRET"

--- a/test/secret-inline.integ.snapshot/SecretIntegrationInline.assets.json
+++ b/test/secret-inline.integ.snapshot/SecretIntegrationInline.assets.json
@@ -1,20 +1,20 @@
 {
   "version": "36.0.0",
   "files": {
-    "fbfa20a153a2fa8b2dd2685813107cbc28e1064a5ba511cdb6114b37e06eaaf7": {
+    "878ec41c762acb5343be65233f78e8443f1be88bb9d4dd2b46f85557146b0c59": {
       "source": {
-        "path": "asset.fbfa20a153a2fa8b2dd2685813107cbc28e1064a5ba511cdb6114b37e06eaaf7.zip",
+        "path": "asset.878ec41c762acb5343be65233f78e8443f1be88bb9d4dd2b46f85557146b0c59.zip",
         "packaging": "file"
       },
       "destinations": {
         "current_account-current_region": {
           "bucketName": "cdk-hnb659fds-assets-${AWS::AccountId}-${AWS::Region}",
-          "objectKey": "fbfa20a153a2fa8b2dd2685813107cbc28e1064a5ba511cdb6114b37e06eaaf7.zip",
+          "objectKey": "878ec41c762acb5343be65233f78e8443f1be88bb9d4dd2b46f85557146b0c59.zip",
           "assumeRoleArn": "arn:${AWS::Partition}:iam::${AWS::AccountId}:role/cdk-hnb659fds-file-publishing-role-${AWS::AccountId}-${AWS::Region}"
         }
       }
     },
-    "4a415dbbac2360ecae292ec17f5072a7230da2024c06f45938f9a788ee4c0706": {
+    "cbd2222d77213bc1b9d79d9b9bb2090a0b1be7cf7d5068966d7c6d0333c9ed5f": {
       "source": {
         "path": "SecretIntegrationInline.template.json",
         "packaging": "file"
@@ -22,7 +22,7 @@
       "destinations": {
         "current_account-current_region": {
           "bucketName": "cdk-hnb659fds-assets-${AWS::AccountId}-${AWS::Region}",
-          "objectKey": "4a415dbbac2360ecae292ec17f5072a7230da2024c06f45938f9a788ee4c0706.json",
+          "objectKey": "cbd2222d77213bc1b9d79d9b9bb2090a0b1be7cf7d5068966d7c6d0333c9ed5f.json",
           "assumeRoleArn": "arn:${AWS::Partition}:iam::${AWS::AccountId}:role/cdk-hnb659fds-file-publishing-role-${AWS::AccountId}-${AWS::Region}"
         }
       }

--- a/test/secret-inline.integ.snapshot/SecretIntegrationInline.template.json
+++ b/test/secret-inline.integ.snapshot/SecretIntegrationInline.template.json
@@ -27,6 +27,7 @@
     "ConvertToJSON": true,
     "Flatten": true,
     "FlattenSeparator": ".",
+    "Plaintext": false,
     "Format": "json",
     "StringifiedValues": true,
     "ResourceType": "SECRET"
@@ -198,7 +199,7 @@
      "S3Bucket": {
       "Fn::Sub": "cdk-hnb659fds-assets-${AWS::AccountId}-${AWS::Region}"
      },
-     "S3Key": "fbfa20a153a2fa8b2dd2685813107cbc28e1064a5ba511cdb6114b37e06eaaf7.zip"
+     "S3Key": "878ec41c762acb5343be65233f78e8443f1be88bb9d4dd2b46f85557146b0c59.zip"
     },
     "Environment": {
      "Variables": {
@@ -247,6 +248,7 @@
     "ConvertToJSON": false,
     "Flatten": true,
     "FlattenSeparator": ".",
+    "Plaintext": false,
     "Format": "yaml",
     "StringifiedValues": true,
     "ResourceType": "SECRET"
@@ -281,6 +283,7 @@
     "ConvertToJSON": true,
     "Flatten": true,
     "FlattenSeparator": ".",
+    "Plaintext": false,
     "Format": "yaml",
     "StringifiedValues": true,
     "ResourceType": "SECRET"
@@ -315,6 +318,7 @@
     "ConvertToJSON": false,
     "Flatten": true,
     "FlattenSeparator": ".",
+    "Plaintext": false,
     "Format": "dotenv",
     "StringifiedValues": true,
     "ResourceType": "SECRET"
@@ -349,6 +353,7 @@
     "ConvertToJSON": true,
     "Flatten": true,
     "FlattenSeparator": ".",
+    "Plaintext": false,
     "Format": "dotenv",
     "StringifiedValues": true,
     "ResourceType": "SECRET"
@@ -383,6 +388,7 @@
     "ConvertToJSON": true,
     "Flatten": false,
     "FlattenSeparator": ".",
+    "Plaintext": false,
     "Format": "json",
     "StringifiedValues": true,
     "ResourceType": "SECRET"
@@ -417,6 +423,7 @@
     "ConvertToJSON": true,
     "Flatten": true,
     "FlattenSeparator": ".",
+    "Plaintext": false,
     "Format": "json",
     "StringifiedValues": true,
     "ResourceType": "SECRET"
@@ -451,6 +458,7 @@
     "ConvertToJSON": false,
     "Flatten": false,
     "FlattenSeparator": ".",
+    "Plaintext": false,
     "Format": "yaml",
     "StringifiedValues": true,
     "ResourceType": "SECRET"
@@ -485,6 +493,7 @@
     "ConvertToJSON": false,
     "Flatten": true,
     "FlattenSeparator": ".",
+    "Plaintext": false,
     "Format": "yaml",
     "StringifiedValues": true,
     "ResourceType": "SECRET"
@@ -519,6 +528,7 @@
     "ConvertToJSON": true,
     "Flatten": false,
     "FlattenSeparator": ".",
+    "Plaintext": false,
     "Format": "yaml",
     "StringifiedValues": true,
     "ResourceType": "SECRET"
@@ -553,6 +563,7 @@
     "ConvertToJSON": true,
     "Flatten": true,
     "FlattenSeparator": ".",
+    "Plaintext": false,
     "Format": "yaml",
     "StringifiedValues": true,
     "ResourceType": "SECRET"

--- a/test/secret-manual.integ.snapshot/SecretIntegrationAsset.assets.json
+++ b/test/secret-manual.integ.snapshot/SecretIntegrationAsset.assets.json
@@ -1,20 +1,20 @@
 {
   "version": "36.0.0",
   "files": {
-    "fbfa20a153a2fa8b2dd2685813107cbc28e1064a5ba511cdb6114b37e06eaaf7": {
+    "878ec41c762acb5343be65233f78e8443f1be88bb9d4dd2b46f85557146b0c59": {
       "source": {
-        "path": "asset.fbfa20a153a2fa8b2dd2685813107cbc28e1064a5ba511cdb6114b37e06eaaf7.zip",
+        "path": "asset.878ec41c762acb5343be65233f78e8443f1be88bb9d4dd2b46f85557146b0c59.zip",
         "packaging": "file"
       },
       "destinations": {
         "current_account-current_region": {
           "bucketName": "cdk-hnb659fds-assets-${AWS::AccountId}-${AWS::Region}",
-          "objectKey": "fbfa20a153a2fa8b2dd2685813107cbc28e1064a5ba511cdb6114b37e06eaaf7.zip",
+          "objectKey": "878ec41c762acb5343be65233f78e8443f1be88bb9d4dd2b46f85557146b0c59.zip",
           "assumeRoleArn": "arn:${AWS::Partition}:iam::${AWS::AccountId}:role/cdk-hnb659fds-file-publishing-role-${AWS::AccountId}-${AWS::Region}"
         }
       }
     },
-    "e9ebefd326b4b3dd2e672cc065b7b6d5fcf9ffaa7127ce26cb565f9689839faf": {
+    "e431252ac43794807ae624a3da04ce3a01589531e000958dcc9de970f46a7290": {
       "source": {
         "path": "SecretIntegrationAsset.template.json",
         "packaging": "file"
@@ -22,7 +22,7 @@
       "destinations": {
         "current_account-current_region": {
           "bucketName": "cdk-hnb659fds-assets-${AWS::AccountId}-${AWS::Region}",
-          "objectKey": "e9ebefd326b4b3dd2e672cc065b7b6d5fcf9ffaa7127ce26cb565f9689839faf.json",
+          "objectKey": "e431252ac43794807ae624a3da04ce3a01589531e000958dcc9de970f46a7290.json",
           "assumeRoleArn": "arn:${AWS::Partition}:iam::${AWS::AccountId}:role/cdk-hnb659fds-file-publishing-role-${AWS::AccountId}-${AWS::Region}"
         }
       }

--- a/test/secret-manual.integ.snapshot/SecretIntegrationAsset.template.json
+++ b/test/secret-manual.integ.snapshot/SecretIntegrationAsset.template.json
@@ -27,6 +27,7 @@
     "ConvertToJSON": true,
     "Flatten": true,
     "FlattenSeparator": ".",
+    "Plaintext": false,
     "Format": "json",
     "StringifiedValues": true,
     "ResourceType": "SECRET"
@@ -72,7 +73,7 @@
      "S3Bucket": {
       "Fn::Sub": "cdk-hnb659fds-assets-${AWS::AccountId}-${AWS::Region}"
      },
-     "S3Key": "fbfa20a153a2fa8b2dd2685813107cbc28e1064a5ba511cdb6114b37e06eaaf7.zip"
+     "S3Key": "878ec41c762acb5343be65233f78e8443f1be88bb9d4dd2b46f85557146b0c59.zip"
     },
     "Environment": {
      "Variables": {
@@ -120,6 +121,7 @@
     "ConvertToJSON": false,
     "Flatten": true,
     "FlattenSeparator": ".",
+    "Plaintext": false,
     "Format": "json",
     "StringifiedValues": true,
     "ResourceType": "SECRET"
@@ -154,6 +156,7 @@
     "ConvertToJSON": true,
     "Flatten": true,
     "FlattenSeparator": ".",
+    "Plaintext": false,
     "Format": "yaml",
     "StringifiedValues": true,
     "ResourceType": "SECRET"
@@ -188,6 +191,7 @@
     "ConvertToJSON": true,
     "Flatten": false,
     "FlattenSeparator": ".",
+    "Plaintext": false,
     "Format": "json",
     "StringifiedValues": true,
     "ResourceType": "SECRET"
@@ -222,6 +226,7 @@
     "ConvertToJSON": true,
     "Flatten": true,
     "FlattenSeparator": ".",
+    "Plaintext": false,
     "Format": "json",
     "StringifiedValues": true,
     "ResourceType": "SECRET"
@@ -256,6 +261,7 @@
     "ConvertToJSON": false,
     "Flatten": false,
     "FlattenSeparator": ".",
+    "Plaintext": false,
     "Format": "yaml",
     "StringifiedValues": true,
     "ResourceType": "SECRET"
@@ -290,6 +296,7 @@
     "ConvertToJSON": false,
     "Flatten": true,
     "FlattenSeparator": ".",
+    "Plaintext": false,
     "Format": "yaml",
     "StringifiedValues": true,
     "ResourceType": "SECRET"
@@ -324,6 +331,7 @@
     "ConvertToJSON": true,
     "Flatten": false,
     "FlattenSeparator": ".",
+    "Plaintext": false,
     "Format": "yaml",
     "StringifiedValues": true,
     "ResourceType": "SECRET"
@@ -358,6 +366,7 @@
     "ConvertToJSON": true,
     "Flatten": true,
     "FlattenSeparator": ".",
+    "Plaintext": false,
     "Format": "yaml",
     "StringifiedValues": true,
     "ResourceType": "SECRET"

--- a/test/secret-multikms.integ.snapshot/SecretMultiKms.assets.json
+++ b/test/secret-multikms.integ.snapshot/SecretMultiKms.assets.json
@@ -1,15 +1,15 @@
 {
   "version": "36.0.0",
   "files": {
-    "fbfa20a153a2fa8b2dd2685813107cbc28e1064a5ba511cdb6114b37e06eaaf7": {
+    "878ec41c762acb5343be65233f78e8443f1be88bb9d4dd2b46f85557146b0c59": {
       "source": {
-        "path": "asset.fbfa20a153a2fa8b2dd2685813107cbc28e1064a5ba511cdb6114b37e06eaaf7.zip",
+        "path": "asset.878ec41c762acb5343be65233f78e8443f1be88bb9d4dd2b46f85557146b0c59.zip",
         "packaging": "file"
       },
       "destinations": {
         "current_account-current_region": {
           "bucketName": "cdk-hnb659fds-assets-${AWS::AccountId}-${AWS::Region}",
-          "objectKey": "fbfa20a153a2fa8b2dd2685813107cbc28e1064a5ba511cdb6114b37e06eaaf7.zip",
+          "objectKey": "878ec41c762acb5343be65233f78e8443f1be88bb9d4dd2b46f85557146b0c59.zip",
           "assumeRoleArn": "arn:${AWS::Partition}:iam::${AWS::AccountId}:role/cdk-hnb659fds-file-publishing-role-${AWS::AccountId}-${AWS::Region}"
         }
       }
@@ -27,7 +27,7 @@
         }
       }
     },
-    "b569986a489766929ff6560e0b05c9e306ec1da96bf8edc1a4229ec3676413b0": {
+    "9fc94e1de96220d90a7b1e248dfcb448d2768e37f8ce65bca4ac56bf91a566ff": {
       "source": {
         "path": "SecretMultiKms.template.json",
         "packaging": "file"
@@ -35,7 +35,7 @@
       "destinations": {
         "current_account-current_region": {
           "bucketName": "cdk-hnb659fds-assets-${AWS::AccountId}-${AWS::Region}",
-          "objectKey": "b569986a489766929ff6560e0b05c9e306ec1da96bf8edc1a4229ec3676413b0.json",
+          "objectKey": "9fc94e1de96220d90a7b1e248dfcb448d2768e37f8ce65bca4ac56bf91a566ff.json",
           "assumeRoleArn": "arn:${AWS::Partition}:iam::${AWS::AccountId}:role/cdk-hnb659fds-file-publishing-role-${AWS::AccountId}-${AWS::Region}"
         }
       }

--- a/test/secret-multikms.integ.snapshot/SecretMultiKms.template.json
+++ b/test/secret-multikms.integ.snapshot/SecretMultiKms.template.json
@@ -189,6 +189,7 @@
     "ConvertToJSON": true,
     "Flatten": true,
     "FlattenSeparator": ".",
+    "Plaintext": false,
     "Format": "json",
     "StringifiedValues": true,
     "ResourceType": "SECRET"
@@ -336,7 +337,7 @@
      "S3Bucket": {
       "Fn::Sub": "cdk-hnb659fds-assets-${AWS::AccountId}-${AWS::Region}"
      },
-     "S3Key": "fbfa20a153a2fa8b2dd2685813107cbc28e1064a5ba511cdb6114b37e06eaaf7.zip"
+     "S3Key": "878ec41c762acb5343be65233f78e8443f1be88bb9d4dd2b46f85557146b0c59.zip"
     },
     "Environment": {
      "Variables": {
@@ -388,6 +389,7 @@
     "ConvertToJSON": true,
     "Flatten": true,
     "FlattenSeparator": ".",
+    "Plaintext": false,
     "Format": "json",
     "StringifiedValues": true,
     "ResourceType": "SECRET"


### PR DESCRIPTION
Fixes #1096. 

This PR adds a new option `plaintext`. If set, we will expect the SOPS file to contain just a single key `data` on toplevel and will sync only the value below this key to the secret. Note that SOPS files always contain a toplevel object, so it was previously impossible to sync just a string to the secret.

![plaintext](https://github.com/user-attachments/assets/634eff68-dc46-43cb-990b-291bddbd2d7d)

Open points:
- Should the key `data` be configurable? Or should we just require that there is exactly one key, no matter its name?
- How does this play with the existing `convertToJson` and `convertToYaml` options? Currently I ignore those, if `plaintext` is true.

@markussiebert Are you ok with the general direction of this PR? If so, I would add some tests for the new functionality. 