### PR TITLE
fix: SopsSync permissions to decrypt the asset file instead of encrypt

### DIFF
--- a/src/SopsSync.ts
+++ b/src/SopsSync.ts
@@ -589,7 +589,7 @@ export namespace Permissions {
           Stack.of(context).synthesizer.bootstrapQualifier ?? 'hnb659fds'; // hnb659fds is the AWS global default qualifier
         Key.fromLookup(context, 'AssetBucketKey', {
           aliasName: `alias/cdk-bootstrap/${qualifier}`,
-        }).grantEncrypt(target);
+        }).grantDecrypt(target);
       } catch (error) {
         Annotations.of(context).addWarningV2(
           'no-asset-kms-key',


### PR DESCRIPTION
In 1.16.12 SopsSync got the permission to encrypt instead of decrypt, which is fixed in this PR.