### PR TITLE
feat: expose singleton uuid for SopsSyncProvider

### DIFF
--- a/API.md
+++ b/API.md
@@ -3060,6 +3060,7 @@ const sopsSyncProviderProps: SopsSyncProviderProps = { ... }
 | <code><a href="#cdk-sops-secrets.SopsSyncProviderProps.property.logRetention">logRetention</a></code> | <code>aws-cdk-lib.aws_logs.RetentionDays</code> | The number of days log events are kept in CloudWatch Logs. |
 | <code><a href="#cdk-sops-secrets.SopsSyncProviderProps.property.role">role</a></code> | <code>aws-cdk-lib.aws_iam.IRole</code> | The role that should be used for the custom resource provider. |
 | <code><a href="#cdk-sops-secrets.SopsSyncProviderProps.property.securityGroups">securityGroups</a></code> | <code>aws-cdk-lib.aws_ec2.ISecurityGroup[]</code> | Only if `vpc` is supplied: The list of security groups to associate with the Lambda's network interfaces. |
+| <code><a href="#cdk-sops-secrets.SopsSyncProviderProps.property.uuid">uuid</a></code> | <code>string</code> | A unique identifier to identify this provider. |
 | <code><a href="#cdk-sops-secrets.SopsSyncProviderProps.property.vpc">vpc</a></code> | <code>aws-cdk-lib.aws_ec2.IVpc</code> | VPC network to place Lambda network interfaces. |
 | <code><a href="#cdk-sops-secrets.SopsSyncProviderProps.property.vpcSubnets">vpcSubnets</a></code> | <code>aws-cdk-lib.aws_ec2.SubnetSelection</code> | Where to place the network interfaces within the VPC. |
 
@@ -3142,6 +3143,21 @@ public readonly securityGroups: ISecurityGroup[];
 - *Default:* A dedicated security group will be created for the lambda function.
 
 Only if `vpc` is supplied: The list of security groups to associate with the Lambda's network interfaces.
+
+---
+
+##### `uuid`<sup>Optional</sup> <a name="uuid" id="cdk-sops-secrets.SopsSyncProviderProps.property.uuid"></a>
+
+```typescript
+public readonly uuid: string;
+```
+
+- *Type:* string
+- *Default:* SopsSyncProvider
+
+A unique identifier to identify this provider.
+
+Overwrite the default, if you need a dedicated provider.
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -221,7 +221,10 @@ const provider = new SopsSyncProvider(this, 'MySopsSyncProvider', {
   securityGroups: [       // securitygroups to your
     customSecurityGroup   // needs.
   ],
-  logGroup: new LogGroup(this, 'MyLogGroup', {RetentionInDays: 90}),  // you can add a custom log group
+  logGroup: new LogGroup(this, 'MyLogGroup', {  // you can add a custom log group
+    retention: RetentionDays.THREE_MONTHS,      // with a custom retention period
+    encryptionKey: new KmsKey(this, 'MyKmsKey') // and custom encryption
+  }),                                           //
 });
 
 provider.addToRolePolicy( // You cann pass PolicyStatements

--- a/README.md
+++ b/README.md
@@ -225,6 +225,7 @@ const provider = new SopsSyncProvider(this, 'MySopsSyncProvider', {
     retention: RetentionDays.THREE_MONTHS,      // with a custom retention period
     encryptionKey: new KmsKey(this, 'MyKmsKey') // and custom encryption
   }),                                           //
+  uuid: 'MySopsSyncProvider',  // Create a custom singleton by changing default uuid.
 });
 
 provider.addToRolePolicy( // You cann pass PolicyStatements

--- a/src/SopsSync.ts
+++ b/src/SopsSync.ts
@@ -227,6 +227,12 @@ export class SopsSyncProvider extends SingletonFunction implements IGrantable {
   private sopsAgeKeys: SecretValue[];
 
   constructor(scope: Construct, id?: string, props?: SopsSyncProviderProps) {
+    if (id === undefined) {
+      Annotations.of(scope).addWarningV2(
+        'cdk-sops-secrets:omittingIdForSopsSyncProvider',
+        'Omitting id is deprecated. Please provide an id for the SopsSyncProvider. Default id will be removed in V3.',
+      );
+    }
     super(scope, id ?? 'SopsSyncProvider', {
       code: Code.fromAsset(
         scope.node.tryGetContext('sops_sync_provider_asset_path') ||
@@ -271,7 +277,8 @@ export class SopsSync extends Construct {
   constructor(scope: Construct, id: string, props: SopsSyncProps) {
     super(scope, id);
 
-    const provider = props.sopsProvider ?? new SopsSyncProvider(scope);
+    const provider =
+      props.sopsProvider ?? new SopsSyncProvider(scope, 'SopsSyncProvider');
 
     let uploadType = props.uploadType ?? UploadType.INLINE;
     let sopsFileFormat: 'json' | 'yaml' | 'dotenv' | 'binary' | undefined =

--- a/src/SopsSync.ts
+++ b/src/SopsSync.ts
@@ -213,6 +213,14 @@ export interface SopsSyncProviderProps {
    * @default `/aws/lambda/${this.functionName}` - default log group created by Lambda
    */
   readonly logGroup?: ILogGroup;
+  /**
+   * A unique identifier to identify this provider
+   *
+   * Overwrite the default, if you need a dedicated provider.
+   *
+   * @default SopsSyncProvider
+   */
+  readonly uuid?: string;
 }
 
 export class SopsSyncProvider extends SingletonFunction implements IGrantable {
@@ -226,7 +234,7 @@ export class SopsSyncProvider extends SingletonFunction implements IGrantable {
       ),
       runtime: Runtime.PROVIDED_AL2,
       handler: 'bootstrap',
-      uuid: 'SopsSyncProvider',
+      uuid: props?.uuid ?? 'SopsSyncProvider',
       role: props?.role,
       timeout: Duration.seconds(60),
       environment: {


### PR DESCRIPTION
A singleton function in AWS CDK is unique by the `uuid`. To create a custom singleton the user may want to overwrite the `uuid` to create a custom one. Because of the nature of AWS CDK singelton functions, the first function created in a stack is always used. Other functions with the same `uuid` would be thrown away.

Additional the default `id` from the SopsSyncProvider is marked deprecated. It has no influence of creating a Singleton or not. So it is better pratice to not have a default value.