### PR TITLE
fix: allow slashes and uppercase letters in alias

### DIFF
--- a/src/SopsSync.ts
+++ b/src/SopsSync.ts
@@ -438,7 +438,7 @@ export namespace Permissions {
   }
 
   export function keysFromSopsContentAlias(ctx: Construct, c: string): IKey[] {
-    const regexAlias = /arn:aws:kms:[a-z0-9-]+:[\d]+:alias\/[a-z0-9-]+/g;
+    const regexAlias = /arn:aws:kms:[a-z0-9-]+:[\d]+:alias\/[a-z0-9-A-Z\/]+/g;
     const resultsAlias = c.match(regexAlias);
     if (resultsAlias !== null) {
       return resultsAlias.map((result, index) =>


### PR DESCRIPTION
Hey, we are currently having problems with aliases for our keys being truncated. Currently, `arn:aws:kms:ab-central-0:123456789111:alias/aBc/defGh` results in a lookup for `alias/a`. This PR allows the alias to contain slashes and uppercase letters.