### PR TITLE
chore: fix recurring typos in comments, log keys, and API docs

### DIFF
--- a/API.md
+++ b/API.md
@@ -2197,7 +2197,7 @@ const multiStringParameterProps: MultiStringParameterProps = { ... }
 | <code><a href="#cdk-sops-secrets.MultiStringParameterProps.property.description">description</a></code> | <code>string</code> | Information about the parameter that you want to add to the system. |
 | <code><a href="#cdk-sops-secrets.MultiStringParameterProps.property.tier">tier</a></code> | <code>aws-cdk-lib.aws_ssm.ParameterTier</code> | The tier of the string parameter. |
 | <code><a href="#cdk-sops-secrets.MultiStringParameterProps.property.keyPrefix">keyPrefix</a></code> | <code>string</code> | The prefix used for all parameters. |
-| <code><a href="#cdk-sops-secrets.MultiStringParameterProps.property.keySeparator">keySeparator</a></code> | <code>string</code> | The seperator used to seperate keys. |
+| <code><a href="#cdk-sops-secrets.MultiStringParameterProps.property.keySeparator">keySeparator</a></code> | <code>string</code> | The separator used to separate keys. |
 
 ---
 
@@ -2394,7 +2394,7 @@ public readonly keySeparator: string;
 - *Type:* string
 - *Default:* '/'
 
-The seperator used to seperate keys.
+The separator used to separate keys.
 
 ---
 
@@ -3705,7 +3705,7 @@ Parse the secret as a binary.
 | **Name** | **Description** |
 | --- | --- |
 | <code><a href="#cdk-sops-secrets.UploadType.INLINE">INLINE</a></code> | Pass the secret data inline (base64 encoded and compressed). |
-| <code><a href="#cdk-sops-secrets.UploadType.ASSET">ASSET</a></code> | Uplaod the secret data as asset. |
+| <code><a href="#cdk-sops-secrets.UploadType.ASSET">ASSET</a></code> | Upload the secret data as asset. |
 
 ---
 
@@ -3718,7 +3718,7 @@ Pass the secret data inline (base64 encoded and compressed).
 
 ##### `ASSET` <a name="ASSET" id="cdk-sops-secrets.UploadType.ASSET"></a>
 
-Uplaod the secret data as asset.
+Upload the secret data as asset.
 
 ---
 

--- a/lambda/handle.go
+++ b/lambda/handle.go
@@ -29,12 +29,12 @@ func handleSecret(props BaseProps) (physicalResourceID string, data map[string]i
 	switch props.properties.ResourceType {
 	case event.SECRET:
 		// The secretsmanager does not support nested json objects, so we have to flatten the data
-		seperator := "."
+		separator := "."
 		if props.properties.FlattenSeparator != nil {
-			seperator = *props.properties.FlattenSeparator
+			separator = *props.properties.FlattenSeparator
 		}
-		logger.Info("Flattening secret data", "seperator", seperator, "ResourceType", props.properties.ResourceType)
-		if err := props.secretDecryptedData.Flatten(seperator); err != nil {
+		logger.Info("Flattening secret data", "separator", separator, "ResourceType", props.properties.ResourceType)
+		if err := props.secretDecryptedData.Flatten(separator); err != nil {
 			return props.properties.GeneratePhysicalResourceId(), nil, err
 		}
 
@@ -81,12 +81,12 @@ func handleSecret(props BaseProps) (physicalResourceID string, data map[string]i
 
 func handleParameterMulti(props BaseProps) (physicalResourceID string, data map[string]interface{}, err error) {
 	logger := slog.With("Package", "main", "Function", "handleParameterMulti")
-	seperator := "/"
+	separator := "/"
 	if props.properties.FlattenSeparator != nil {
-		seperator = *props.properties.FlattenSeparator
+		separator = *props.properties.FlattenSeparator
 	}
-	logger.Info("Flattening secret data", "seperator", seperator)
-	if err := props.secretDecryptedData.Flatten(seperator); err != nil {
+	logger.Info("Flattening secret data", "separator", separator)
+	if err := props.secretDecryptedData.Flatten(separator); err != nil {
 		return props.properties.GeneratePhysicalResourceId(), nil, err
 	}
 	logger.Info("Stringify values in data")
@@ -104,10 +104,10 @@ func handleParameterMulti(props BaseProps) (physicalResourceID string, data map[
 	logger.Info("Writing secret data to parameter store")
 	for key, value := range outData {
 		// As we flatten array to [number] path notations, we have to fix this for parameter store
-		fixedKey := strings.ReplaceAll(key, "[", seperator)
-		fixedKey = strings.ReplaceAll(fixedKey, "]", seperator)
-		fixedKey = strings.TrimSuffix(fixedKey, seperator)
-		fixedKey = strings.ReplaceAll(fixedKey, seperator+seperator, seperator)
+		fixedKey := strings.ReplaceAll(key, "[", separator)
+		fixedKey = strings.ReplaceAll(fixedKey, "]", separator)
+		fixedKey = strings.TrimSuffix(fixedKey, separator)
+		fixedKey = strings.ReplaceAll(fixedKey, separator+separator, separator)
 		// The secret name can contain ASCII letters, numbers, and the following characters: /_+=.@-
 		allowedChars := "/_+=.@-"
 		for i, char := range fixedKey {

--- a/lambda/main.go
+++ b/lambda/main.go
@@ -104,7 +104,7 @@ func HandleRequestWithClients(clients client.AwsClient, e cfn.Event) (physicalRe
 		secretDecryptedData: secretDecryptedData,
 	}
 
-	// Fill the secret values in the ressource depending on the ressource type
+	// Fill the secret values in the resource depending on the resource type
 	switch props.ResourceType {
 	case event.SECRET, event.SECRET_RAW, event.SECRET_BINARY:
 		return handleSecret(baseProps)

--- a/src/MultiStringParameter.ts
+++ b/src/MultiStringParameter.ts
@@ -11,7 +11,7 @@ import {
 
 export interface MultiStringParameterProps extends SopsCommonParameterProps {
   /**
-   * The seperator used to seperate keys
+   * The separator used to separate keys
    *
    * @default - '/'
    */

--- a/src/SopsSecret.ts
+++ b/src/SopsSecret.ts
@@ -354,7 +354,7 @@ export class SopsSecret extends Construct implements ISecret {
     super(scope, id);
     this.secret = new Secret(this, 'Resource', props satisfies SecretProps);
 
-    // Fullfill secret Interface
+    // Fulfill secret Interface
     this.encryptionKey = this.secret.encryptionKey;
     this.secretArn = this.secret.secretArn;
     this.secretName = this.secret.secretName;

--- a/src/SopsSync.ts
+++ b/src/SopsSync.ts
@@ -32,7 +32,7 @@ export enum UploadType {
    */
   INLINE = 'INLINE',
   /**
-   * Uplaod the secret data as asset
+   * Upload the secret data as asset
    */
   ASSET = 'ASSET',
 }
@@ -413,7 +413,7 @@ export class SopsSync extends Construct {
       }
 
       if (
-        // Is allways true, but to satisfy TS we check explicitly
+        // Is always true, but to satisfy TS we check explicitly
         provider.role !== undefined &&
         // Check if user has disabled automatic generation
         props.autoGenerateIamPermissions !== false
@@ -646,7 +646,7 @@ export namespace Permissions {
       } catch (error) {
         Annotations.of(context).addWarningV2(
           'no-asset-kms-key',
-          `An error occured while retreving the KMS-Key for the Asset S3-Bucket from CDK Bootstrap. Set encryption key manually by using props.assetEncryptionKey. ${error}`,
+          `An error occurred while retrieving the KMS-Key for the Asset S3-Bucket from CDK Bootstrap. Set encryption key manually by using props.assetEncryptionKey. ${error}`,
         );
       }
     }


### PR DESCRIPTION
## Summary

Fixes recurring typos across source comments, a Go variable name, slog field keys, a runtime warning string, and the generated `API.md`. Purely cosmetic; no functional or public API changes.

## Changes

| Typo | Fix | Location |
| --- | --- | --- |
| `seperator` | `separator` | `lambda/handle.go` (internal variable + slog keys), `src/MultiStringParameter.ts` (doc comment), `API.md` |
| `Uplaod` | `Upload` | `src/SopsSync.ts` (`UploadType.ASSET` doc), `API.md` |
| `allways` | `always` | `src/SopsSync.ts` (comment) |
| `occured` / `retreving` | `occurred` / `retrieving` | `src/SopsSync.ts` (warning string) |
| `Fullfill` | `Fulfill` | `src/SopsSecret.ts` (comment) |
| `ressource` | `resource` | `lambda/main.go` (comment) |

## Notes

- No public API names changed. The renamed Go identifier (`seperator`) is a function-local variable; the `FlattenSeparator` custom-resource property was already spelled correctly and is untouched.
- `API.md` is generated by `mise run jsii-docgen`. A full regeneration also pulls in unrelated drift from the current `aws-cdk-lib` version (a new inherited member), so to keep this PR focused the four affected lines in `API.md` were edited by hand instead. CI (`mise run build`) does not regenerate or diff `API.md`, so this stays consistent.

## Testing

- `mise run lambda:test` — pass (Go, coverage 81.5%)
- `CI=true mise run cdk:test:jest` — pass (55 tests, 3 snapshots)

---

_Drafted with AI assistance. Agent: Kiro. Model: claude-opus-4.8._
